### PR TITLE
Make FAST_INT_BINDING strict again.

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -138,7 +138,7 @@ executable happy
 
   build-depends: base < 5, mtl >= 1.0
 
-  extensions: CPP, MagicHash
+  extensions: CPP, MagicHash, BangPatterns
   ghc-options: -Wall -fno-warn-type-defaults
   other-modules:
         AbsSyn

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -2,7 +2,7 @@
 
 #ifdef HAPPY_GHC
 #define ILIT(n) n#
-#define FAST_INT_BINDING(n) (n)
+#define FAST_INT_BINDING(n) !(n)
 #define IBOX(n) (Happy_GHC_Exts.I# (n))
 #define FAST_INT Happy_GHC_Exts.Int#
 #define LT(n,m) (n Happy_GHC_Exts.<# m)


### PR DESCRIPTION
For [GHC ticket ~~#8102~~ #8022](http://ghc.haskell.org/trac/ghc/ticket/8022), the compiler bootstrap will fail using `happy-1.8.10` since it will now reject the invalid lifted pattern by default in the `stage2` build.

It would be nice to see this merged and `happy-1.8.11` released for developers. (It's always nice to get rid of old crufty warnings and whatnot.)
