### PR TITLE
Removes tabs from GenericTemplate.hs, which cause problems with clang in...

### DIFF
--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -67,11 +67,11 @@ data Happy_IntList = HappyCons FAST_INT Happy_IntList
 #if defined(HAPPY_COERCE)
 #define GET_ERROR_TOKEN(x)  (case Happy_GHC_Exts.unsafeCoerce# x of { IBOX(i) -> i })
 #define MK_ERROR_TOKEN(i)   (Happy_GHC_Exts.unsafeCoerce# IBOX(i))
-#define MK_TOKEN(x)	    (happyInTok (x))
+#define MK_TOKEN(x)         (happyInTok (x))
 #else
 #define GET_ERROR_TOKEN(x)  (case x of { HappyErrorToken IBOX(i) -> i })
 #define MK_ERROR_TOKEN(i)   (HappyErrorToken IBOX(i))
-#define MK_TOKEN(x)	    (HappyTerminal (x))
+#define MK_TOKEN(x)         (HappyTerminal (x))
 #endif
 
 #if defined(HAPPY_DEBUG)
@@ -98,9 +98,9 @@ happyParse start_state = happyNewToken start_state notHappyAtAll notHappyAtAll
 -- parse (a %partial parser).  We must ignore the saved token on the top of
 -- the stack in this case.
 happyAccept ERROR_TOK tk st sts (_ `HappyStk` ans `HappyStk` _) =
-	happyReturn1 ans
+        happyReturn1 ans
 happyAccept j tk st sts (HappyStk ans _) = 
-	IF_GHC(happyTcHack j IF_ARRAYS(happyTcHack st)) (happyReturn1 ans)
+        IF_GHC(happyTcHack j IF_ARRAYS(happyTcHack st)) (happyReturn1 ans)
 
 -----------------------------------------------------------------------------
 -- Arrays only: do the next action
@@ -108,35 +108,35 @@ happyAccept j tk st sts (HappyStk ans _) =
 #if defined(HAPPY_ARRAY)
 
 happyDoAction i tk st
-	= DEBUG_TRACE("state: " ++ show IBOX(st) ++ 
-		      ",\ttoken: " ++ show IBOX(i) ++
-		      ",\taction: ")
-	  case action of
-		ILIT(0)		  -> DEBUG_TRACE("fail.\n")
-				     happyFail i tk st
-		ILIT(-1) 	  -> DEBUG_TRACE("accept.\n")
-				     happyAccept i tk st
-		n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
-						 ++ ")")
-				     (happyReduceArr Happy_Data_Array.! rule) i tk st
-				     where rule = IBOX(NEGATE(PLUS(n,(ILIT(1) :: FAST_INT))))
-		n		  -> DEBUG_TRACE("shift, enter state "
-						 ++ show IBOX(new_state)
-						 ++ "\n")
-				     happyShift new_state i tk st
+        = DEBUG_TRACE("state: " ++ show IBOX(st) ++ 
+                      ",\ttoken: " ++ show IBOX(i) ++
+                      ",\taction: ")
+          case action of
+                ILIT(0)           -> DEBUG_TRACE("fail.\n")
+                                     happyFail i tk st
+                ILIT(-1)          -> DEBUG_TRACE("accept.\n")
+                                     happyAccept i tk st
+                n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
+                                                               ++ ")")
+                                                   (happyReduceArr Happy_Data_Array.! rule) i tk st
+                                                   where rule = IBOX(NEGATE(PLUS(n,(ILIT(1) :: FAST_INT))))
+                n                 -> DEBUG_TRACE("shift, enter state "
+                                                 ++ show IBOX(new_state)
+                                                 ++ "\n")
+                                     happyShift new_state i tk st
                                      where new_state = MINUS(n,(ILIT(1) :: FAST_INT))
    where off    = indexShortOffAddr happyActOffsets st
          off_i  = PLUS(off,i)
-	 check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
+         check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
-		  else False
+                  else False
          action
           | check     = indexShortOffAddr happyTable off_i
           | otherwise = indexShortOffAddr happyDefActions st
 
 #ifdef HAPPY_GHC
 indexShortOffAddr (HappyA# arr) off =
-	Happy_GHC_Exts.narrow16Int# i
+        Happy_GHC_Exts.narrow16Int# i
   where
         i = Happy_GHC_Exts.word2Int# (Happy_GHC_Exts.or# (Happy_GHC_Exts.uncheckedShiftL# high 8#) low)
         high = Happy_GHC_Exts.int2Word# (Happy_GHC_Exts.ord# (Happy_GHC_Exts.indexCharOffAddr# arr (off' Happy_GHC_Exts.+# 1#)))
@@ -207,9 +207,9 @@ happyReduce k i fn ERROR_TOK tk st sts stk
      = happyFail ERROR_TOK tk st sts stk
 happyReduce k nt fn j tk st sts stk
      = case happyDrop MINUS(k,(ILIT(1) :: FAST_INT)) sts of
-	 sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
-        	let r = fn stk in  -- it doesn't hurt to always seq here...
-       		happyDoSeq r (GOTO(action) nt j tk st1 sts1 r)
+         sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
+                let r = fn stk in  -- it doesn't hurt to always seq here...
+                happyDoSeq r (GOTO(action) nt j tk st1 sts1 r)
 
 happyMonadReduce k nt fn ERROR_TOK tk st sts stk
      = happyFail ERROR_TOK tk st sts stk
@@ -261,7 +261,7 @@ happyGoto action j tk st = action j j tk (HappyState action)
 -- parse error if we are in recovery and we fail again
 happyFail ERROR_TOK tk old_st _ stk@(x `HappyStk` _) =
      let i = GET_ERROR_TOKEN(x) in
---	trace "failing" $ 
+--      trace "failing" $ 
         happyError_ i tk
 
 {-  We don't need state discarding for our restricted implementation of
@@ -270,16 +270,16 @@ happyFail ERROR_TOK tk old_st _ stk@(x `HappyStk` _) =
 
 -- discard a state
 happyFail  ERROR_TOK tk old_st CONS(HAPPYSTATE(action),sts) 
-						(saved_tok `HappyStk` _ `HappyStk` stk) =
---	trace ("discarding state, depth " ++ show (length stk))  $
-	DO_ACTION(action,ERROR_TOK,tk,sts,(saved_tok`HappyStk`stk))
+                                                (saved_tok `HappyStk` _ `HappyStk` stk) =
+--      trace ("discarding state, depth " ++ show (length stk))  $
+        DO_ACTION(action,ERROR_TOK,tk,sts,(saved_tok`HappyStk`stk))
 -}
 
 -- Enter error recovery: generate an error token,
 --                       save the old token and carry on.
 happyFail  i tk HAPPYSTATE(action) sts stk =
 --      trace "entering error recovery" $
-	DO_ACTION(action,ERROR_TOK,tk,sts, MK_ERROR_TOKEN(i) `HappyStk` stk)
+        DO_ACTION(action,ERROR_TOK,tk,sts, MK_ERROR_TOKEN(i) `HappyStk` stk)
 
 -- Internal happy errors:
 
@@ -297,9 +297,9 @@ happyTcHack x y = y
 
 -----------------------------------------------------------------------------
 -- Seq-ing.  If the --strict flag is given, then Happy emits 
---	happySeq = happyDoSeq
+--      happySeq = happyDoSeq
 -- otherwise it emits
--- 	happySeq = happyDontSeq
+--      happySeq = happyDontSeq
 
 happyDoSeq, happyDontSeq :: a -> b -> b
 happyDoSeq   a b = a `seq` b


### PR DESCRIPTION
Hi Simon —
Here's a simple patch to strip tabs from GenericTemplate.hs. This fixes errors when building GHC using the version of clang included with Xcode 5.
