### PR TITLE
Converting clang's line makers to GHC's line pragma.

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -30,6 +30,13 @@ mungeLinePragma line = case symbols line of
    -> case reads number of
         [(n, "")] -> "{-# LINE " ++ show (n :: Int) ++ " " ++ string ++ " #-}"
         _         -> line
+ -- For clang
+ ["#", number, string, _] | length string >= 2
+                      && head string == '"'
+                      && last string == '"'
+   -> case reads number of
+        [(n, "")] -> "{-# LINE " ++ show (n :: Int) ++ " " ++ string ++ " #-}"
+        _         -> line
  -- Also convert old-style CVS lines, no idea why we do this...
  ("--":"$":"Id":":":_) -> filter (/='$') line
  (     "$":"Id":":":_) -> filter (/='$') line


### PR DESCRIPTION
Some of clang's line makers have four items:

```
----
#1 "<built-in>" 1
----
```

This cannot be parsed by Setup and is left in a template as is,
resulting in compile errors with GHC/clang-wrapper later.
