### PR TITLE
use Base instead of Haskell98 in GLR examples

### DIFF
--- a/examples/glr/bio-eg/Bio.y
+++ b/examples/glr/bio-eg/Bio.y
@@ -3,7 +3,7 @@
 -- (c) 2004 University of Durham, Julia Fischer
 -- Portions of the grammar are derived from work by Leung/Mellish/Robertson
 
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/bio-eg/Main.lhs
+++ b/examples/glr/bio-eg/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import Bio
 > import qualified Data.Map as Map

--- a/examples/glr/bio-eg/Makefile
+++ b/examples/glr/bio-eg/Makefile
@@ -11,7 +11,7 @@ FILTER =
 	@ dummy 
 
 ${PROG} : Bio.o Main.lhs 
-	${GHC} -cpp -fglasgow-exts  -o ${PROG} --make Main.lhs
+	${GHC} -cpp -fglasgow-exts -rtsopts  -o ${PROG} --make Main.lhs
 
 BioData.hs Bio.hs : Bio.y
 	${HAPPY} --info --glr --ghc ${FILTER} $< 

--- a/examples/glr/expr-eval/Expr.y
+++ b/examples/glr/expr-eval/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/expr-eval/Main.lhs
+++ b/examples/glr/expr-eval/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/examples/glr/expr-monad/Expr.y
+++ b/examples/glr/expr-monad/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/expr-monad/Main.lhs
+++ b/examples/glr/expr-monad/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/examples/glr/expr-tree/Expr.y
+++ b/examples/glr/expr-tree/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 import Tree 
 }
 

--- a/examples/glr/expr-tree/Main.lhs
+++ b/examples/glr/expr-tree/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/examples/glr/hidden-leftrec/Expr.y
+++ b/examples/glr/hidden-leftrec/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/hidden-leftrec/Main.lhs
+++ b/examples/glr/hidden-leftrec/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/examples/glr/highly-ambiguous/Expr.y
+++ b/examples/glr/highly-ambiguous/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/highly-ambiguous/Main.lhs
+++ b/examples/glr/highly-ambiguous/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/examples/glr/nlp/English.y
+++ b/examples/glr/nlp/English.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/nlp/Main.lhs
+++ b/examples/glr/nlp/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import English

--- a/examples/glr/packing/Expr.y
+++ b/examples/glr/packing/Expr.y
@@ -1,6 +1,6 @@
 {
 -- only list imports here
-import Char
+import Data.Char
 }
 
 %tokentype { Token }

--- a/examples/glr/packing/Main.lhs
+++ b/examples/glr/packing/Main.lhs
@@ -1,5 +1,5 @@
 > module Main where
-> import System(getArgs)
+> import System.Environment(getArgs)
 > import Data.Maybe(fromJust)
 > import qualified Data.Map as Map
 > import Expr

--- a/templates/GLR_Lib.hs
+++ b/templates/GLR_Lib.hs
@@ -40,7 +40,6 @@
   where
 
 import Data.Char
-import System
 import qualified Data.Map as Map
 
 import Control.Monad (foldM)


### PR DESCRIPTION
Hello,
I fix some minor points in order to compile the GLR example with the haskell-platform shipped with fedora
