### PR TITLE
Fix a bug in the Lexer

### DIFF
--- a/src/Lexer.lhs
+++ b/src/Lexer.lhs
@@ -218,8 +218,8 @@ Utilities that read the rest of a token.
 >       || c == '_'
 
 > lexReadSingleChar :: String -> (String -> String -> a) -> a
-> lexReadSingleChar (c:'\'':r)      fn = fn (c:"'") r
 > lexReadSingleChar ('\\':c:'\'':r) fn = fn ('\\':c:"'") r
+> lexReadSingleChar (c:'\'':r)      fn = fn (c:"'") r
 > lexReadSingleChar r               fn = fn "" r
 
 > lexReadChar :: String -> (String -> String -> a) -> a


### PR DESCRIPTION
Fixes #33 caused by wrong pattern matching order in the `lexReadSingleChar` function.
