### PR TITLE
Instructions how to build the happy documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cabal-dev
 cabal.sandbox.config
 .*.swp
 .*.swo
+/.vscode/

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,7 @@
+autom4te.cache/
+config.log
+config.mk
+config.status
+configure
+happy/
+happy.1

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,25 @@
+# Building the Happy documentation
+
+In this directory, run:
+```
+autoconf
+./configure
+make
+```
+On success, you should find the documentation in the
+subdirectory `happy/`.
+
+## Troubleshooting
+
+Running `./configure` might report:
+```
+checking for DocBook XSL stylesheet directory... no
+configure: WARNING: cannot find DocBook XSL stylesheets, you will not be able to build the documentation
+```
+Extending the list `FP_DIR_DOCBOOK_XSL` in file `configure.ac` might
+help.  E.g., on Mac OS X with homebrew-installed `docbook`, the path
+```
+/usr/local/Cellar/docbook-xsl/*/docbook-xsl
+```
+worked.  Inside this directory (pattern), `configure` looks for a file
+`/html/docbook.xsl`, see `aclocal.m4`.

--- a/doc/configure.ac
+++ b/doc/configure.ac
@@ -1,11 +1,11 @@
 
-AC_INIT([Haddock docs], [1.0], [simonmar@microsoft.com], [])
+AC_INIT([Happy docs], [1.0], [smarlow@fb.com], [])
 
 AC_CONFIG_SRCDIR([Makefile])
 
 dnl ** check for DocBook toolchain
 FP_CHECK_DOCBOOK_DTD
-FP_DIR_DOCBOOK_XSL([/usr/share/xml/docbook/stylesheet/nwalsh/current /usr/share/xml/docbook/stylesheet/nwalsh /usr/share/sgml/docbook/docbook-xsl-stylesheets* /usr/share/sgml/docbook/xsl-stylesheets* /opt/kde?/share/apps/ksgmltools2/docbook/xsl /usr/share/docbook-xsl /usr/share/sgml/docbkxsl /usr/local/share/xsl/docbook /sw/share/xml/xsl/docbook-xsl /usr/share/xml/docbook/xsl-stylesheets*])
+FP_DIR_DOCBOOK_XSL([/usr/local/Cellar/docbook-xsl/*/docbook-xsl /usr/share/xml/docbook/stylesheet/nwalsh/current /usr/share/xml/docbook/stylesheet/nwalsh /usr/share/sgml/docbook/docbook-xsl-stylesheets* /usr/share/sgml/docbook/xsl-stylesheets* /opt/kde?/share/apps/ksgmltools2/docbook/xsl /usr/share/docbook-xsl /usr/share/sgml/docbkxsl /usr/local/share/xsl/docbook /sw/share/xml/xsl/docbook-xsl /usr/share/xml/docbook/xsl-stylesheets*])
 
 AC_PATH_PROG(DbLatexCmd,dblatex)
 


### PR DESCRIPTION
Instructions how to build the happy documentation.
Also, adding path to DocBook stylesheets (xsl) when installed on Mac via HomeBrew.