### PR TITLE
use unicode

### DIFF
--- a/doc/happy.xml
+++ b/doc/happy.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
 


### PR DESCRIPTION
#228 replaced Ljungloef with Ljunglöf

.html and .pdf generation now correct

@Ericson2314 

can you close https://github.com/haskell/happy/issues/62