### PR TITLE
Update to the latest Haskell CI (0.15.20230203)

### DIFF
--- a/.github/haskell-ci.patch
+++ b/.github/haskell-ci.patch
@@ -1,6 +1,6 @@
---- workflows/haskell-ci.yml	2022-02-28 01:09:37.000000000 +0100
-+++ workflows/haskell-ci.yml-patched	2022-02-28 01:08:00.000000000 +0100
-@@ -127,12 +127,14 @@
+--- .github/workflows/haskell-ci.yml	2023-02-06 09:35:15.000000000 +0100
++++ .github/workflows/haskell-ci.yml-patched	2023-02-06 09:34:40.000000000 +0100
+@@ -139,12 +139,14 @@
            HCDIR=/opt/$HCKIND/$HCVER
            if [ "${{ matrix.setup-method }}" = ghcup ]; then
              HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
@@ -8,23 +8,23 @@
              echo "HC=$HC" >> "$GITHUB_ENV"
              echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
              echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-             echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+             echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
            else
              HC=$HCDIR/bin/$HCKIND
 +            echo "$HCDIR/bin" >> "$GITHUB_PATH"
              echo "HC=$HC" >> "$GITHUB_ENV"
              echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
              echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-@@ -264,7 +266,7 @@
+@@ -291,7 +293,7 @@
            cat cabal.project.local
        - name: dump install plan
          run: |
 -          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
 +          $CABAL v2-build --flags=-bootstrap $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
            cabal-plan
-       - name: cache
-         uses: actions/cache@v2
-@@ -274,17 +276,20 @@
+       - name: restore cache
+         uses: actions/cache/restore@v3
+@@ -301,17 +303,20 @@
            restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
        - name: install dependencies
          run: |
@@ -51,9 +51,12 @@
        - name: cabal check
          run: |
            cd ${PKGDIR_happy_backend_lalr} || false
-@@ -307,4 +312,4 @@
+@@ -334,7 +339,7 @@
        - name: unconstrained build
          run: |
            rm -f cabal.project.local
 -          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
 +          $CABAL v2-build --flags=-bootstrap $ARG_COMPILER --disable-tests --disable-benchmarks all
+       - name: save cache
+         uses: actions/cache/save@v3
+         if: always()

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.1
+# version: 0.15.20230203
 #
-# REGENDATA ("0.14.1",["github","cabal.project","--config","cabal.haskell-ci","--project"])
+# REGENDATA ("0.15.20230203",["github","cabal.project","--config","cabal.haskell-ci","--project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.6.0.20230128
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.6.0.20230128
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.4.4
+            compilerKind: ghc
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.5
+            compilerKind: ghc
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -101,18 +111,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -131,21 +143,21 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "$HCDIR/bin" >> "$GITHUB_PATH"
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -174,6 +186,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -197,7 +221,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -261,6 +285,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(containers|happy|happy-backend-glr|happy-backend-lalr|happy-codegen-common|happy-frontend|happy-grammar|happy-tabular|mtl|transformers)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -268,8 +295,8 @@ jobs:
         run: |
           $CABAL v2-build --flags=-bootstrap $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -308,8 +335,14 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build --flags=-bootstrap $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -23,3 +23,37 @@ When new GHC versions become available, CI can be updated by
 This should work as long as `haskell-ci` does not change its generated
 workflow too much.  Otherwise, the patch might not apply cleanly and
 the workflow has to be patched manually.
+
+2023-02-06 Updating to a new version of Haskell-CI
+--------------------------------------------------
+
+1. Install Haskell-CI from its source repo:
+
+        pushd /tmp
+        git clone https://github.com/haskell-CI/haskell-ci.git
+        cd haskell-ci
+        cabal install
+        popd
+
+2. Update the `tested-with` fields in the `.cabal` files.
+
+3. Follow the instructions to regenerate the Haskell CI workflow, which are:
+
+        haskell-ci regenerate
+        patch --input=.github/haskell-ci.patch .github/workflows/haskell-ci.yml
+
+If some hunks fail to apply in the last step, the patch as to be updated.
+
+4. Apply the remaining hunks manually.
+
+5. Save the patched workflow, regenerate the original workflow, regenerate the patch
+
+        cp .github/workflows/haskell-ci.yml .github/workflows/haskell-ci.yml-patched
+        haskell-ci regenerate
+        diff -u .github/workflows/haskell-ci.yml .github/workflows/haskell-ci.yml-patched > .github/haskell-ci.patch
+
+6. Now the patch will apply cleanly.
+
+        patch --input=.github/haskell-ci.patch .github/workflows/haskell-ci.yml
+
+7. Commit the updated files (no extra files need to be committed).

--- a/happy.cabal
+++ b/happy.cabal
@@ -19,7 +19,9 @@ Description:
   grammar.  Happy works in a similar way to the @yacc@ tool for C.
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/backend-glr/happy-backend-glr.cabal
+++ b/packages/backend-glr/happy-backend-glr.cabal
@@ -20,7 +20,9 @@ Description:
 
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/backend-lalr/happy-backend-lalr.cabal
+++ b/packages/backend-lalr/happy-backend-lalr.cabal
@@ -20,7 +20,9 @@ Description:
 
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/codegen-common/happy-codegen-common.cabal
+++ b/packages/codegen-common/happy-codegen-common.cabal
@@ -19,7 +19,9 @@ Description:
   which represents a directives as can be parsed and processed by happy.
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/frontend/happy-frontend.cabal
+++ b/packages/frontend/happy-frontend.cabal
@@ -21,7 +21,9 @@ Description:
   have some Haskell-specific features.
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/grammar/happy-grammar.cabal
+++ b/packages/grammar/happy-grammar.cabal
@@ -19,7 +19,9 @@ Description:
   which represents a grammar as can be parsed and processed by happy.
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4

--- a/packages/tabular/happy-tabular.cabal
+++ b/packages/tabular/happy-tabular.cabal
@@ -20,7 +20,9 @@ Description:
   which are further processed by a backend.
 
 tested-with:
-        GHC == 9.2.1
+        GHC == 9.6.0
+        GHC == 9.4.4
+        GHC == 9.2.5
         GHC == 9.0.2
         GHC == 8.10.7
         GHC == 8.8.4


### PR DESCRIPTION
Update to the latest Haskell CI (0.15.20230203)
- update `tested-with` in the `.cabal` files
- update the patch to apply cleanly to the latest Haskell-CI generated workflow
- update developer manual with step to update the patch
- update `haskell-ci.yml`

I split this into several patches as some of these could be applied to the `release-1.20` branch, but not all.  See:
- #248