### PR TITLE
Fix sdist

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Revision history for Happy
 
-## Unreleased
+## 2.0
 
 The main focus of this release was modularizing Happy.
 
@@ -11,6 +11,9 @@ The main focus of this release was modularizing Happy.
   - `happy-frontend`
   - `happy-grammar`
   - `happy-tabular`
+
+* Partially revert the new bootstrapping system of 1.21.0 to mitigate
+  build issues.
 
 ## 1.21.0
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ sdist ::
 		echo "Error: Tree is not clean"; \
 		exit 1; \
 	fi
-	$(CABAL) v2-sdist
+	$(CABAL) v2-sdist all
 	@if [ ! -f "${SDIST_DIR}/happy-$(HAPPY_VER).tar.gz" ]; then \
 		echo "Error: source tarball not found: dist/happy-$(HAPPY_VER).tar.gz"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@ CABAL = cabal
 
 HAPPY_VER = `awk '/^version:/ { print $$2 }' happy.cabal`
 
-ALEX = alex
-ALEX_OPTS = -g
-
 SDIST_DIR=dist-newstyle/sdist
 
 sdist ::

--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -1,0 +1,35 @@
+import Control.Monad
+import Data.Foldable
+import System.FilePath
+import System.Directory
+import System.Process
+import System.Exit
+
+main :: IO ()
+main = do
+  let bootstrap_root = "./bootstrap-root"
+      happy_boot = bootstrap_root </> "happy"
+  callProcess "cabal"
+    [ "install", "happy",
+      "-f", "-bootstrap",
+      "--installdir=" ++ bootstrap_root ]
+  with_y_files "packages" $ \y_file -> do
+    putStrLn $ "Processing " ++ show y_file
+    callProcess happy_boot [y_file]
+    removeFile y_file
+  removePathForcibly bootstrap_root
+
+with_y_files :: FilePath -> (FilePath -> IO ()) -> IO ()
+with_y_files path cont = do
+  is_dir <- doesDirectoryExist path
+  if is_dir then do
+    entries <- listDirectory path
+    for_ entries $ \entry ->
+      with_y_files (path </> entry) cont
+  else do
+    is_file <- doesFileExist path
+    if is_file then do
+      let ext = takeExtension path
+      when (ext == ".y" || ext == ".ly") (cont path)
+    else do
+      die ("Neither file nor dir: " ++ show path)

--- a/happy.cabal
+++ b/happy.cabal
@@ -1,5 +1,5 @@
 name: happy
-version: 1.21.0
+version: 2.0
 license: BSD2
 license-file: LICENSE
 copyright: (c) Andy Gill, Simon Marlow
@@ -142,12 +142,12 @@ executable happy
                  array,
                  containers >= 0.4.2,
                  mtl >= 2.2.1,
-                 happy-codegen-common == 1.21.0,
-                 happy-grammar == 1.21.0,
-                 happy-tabular == 1.21.0,
-                 happy-frontend == 1.21.0,
-                 happy-backend-lalr == 1.21.0,
-                 happy-backend-glr == 1.21.0
+                 happy-codegen-common == 2.0,
+                 happy-grammar == 2.0,
+                 happy-tabular == 2.0,
+                 happy-frontend == 2.0,
+                 happy-backend-lalr == 2.0,
+                 happy-backend-glr == 2.0
 
   default-language: Haskell98
   default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns

--- a/packages/backend-glr/happy-backend-glr.cabal
+++ b/packages/backend-glr/happy-backend-glr.cabal
@@ -1,5 +1,5 @@
 name:            happy-backend-glr
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow
@@ -49,9 +49,9 @@ library
                        Happy.Backend.GLR.ProduceCode
   build-depends:       base < 5,
                        array,
-                       happy-codegen-common == 1.21.0,
-                       happy-grammar == 1.21.0,
-                       happy-tabular == 1.21.0
+                       happy-codegen-common == 2.0,
+                       happy-grammar == 2.0,
+                       happy-tabular == 2.0
 
   default-language:    Haskell98
   default-extensions:  CPP, MagicHash, FlexibleContexts

--- a/packages/backend-lalr/happy-backend-lalr.cabal
+++ b/packages/backend-lalr/happy-backend-lalr.cabal
@@ -1,5 +1,5 @@
 name:            happy-backend-lalr
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow
@@ -49,9 +49,9 @@ library
                        Happy.Backend.LALR.ProduceCode
   build-depends:       base < 5,
                        array,
-                       happy-codegen-common == 1.21.0,
-                       happy-grammar == 1.21.0,
-                       happy-tabular == 1.21.0
+                       happy-codegen-common == 2.0,
+                       happy-grammar == 2.0,
+                       happy-tabular == 2.0
 
   default-language:    Haskell98
   default-extensions:  CPP, MagicHash, FlexibleContexts

--- a/packages/codegen-common/happy-codegen-common.cabal
+++ b/packages/codegen-common/happy-codegen-common.cabal
@@ -1,5 +1,5 @@
 name:            happy-codegen-common
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow

--- a/packages/frontend/happy-frontend.cabal
+++ b/packages/frontend/happy-frontend.cabal
@@ -1,5 +1,5 @@
 name:            happy-frontend
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow
@@ -54,8 +54,8 @@ library
                        containers >= 0.4.2,
                        transformers >= 0.5.6.2,
                        mtl >= 2.2.2,
-                       happy-codegen-common == 1.21.0,
-                       happy-grammar == 1.21.0
+                       happy-codegen-common == 2.0,
+                       happy-grammar == 2.0
 
   default-language:    Haskell98
   default-extensions:  CPP, MagicHash, FlexibleContexts

--- a/packages/grammar/happy-grammar.cabal
+++ b/packages/grammar/happy-grammar.cabal
@@ -1,5 +1,5 @@
 name:            happy-grammar
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow

--- a/packages/tabular/happy-tabular.cabal
+++ b/packages/tabular/happy-tabular.cabal
@@ -1,5 +1,5 @@
 name:            happy-tabular
-version:         1.21.0
+version:         2.0
 license:         BSD2
 license-file:    LICENSE
 copyright:       (c) Andy Gill, Simon Marlow
@@ -47,7 +47,7 @@ library
   build-depends:       base < 5,
                        array,
                        containers >= 0.4.2,
-                       happy-grammar == 1.21.0
+                       happy-grammar == 2.0
 
   default-language:    Haskell98
   default-extensions:  CPP, MagicHash, FlexibleContexts, NamedFieldPuns


### PR DESCRIPTION
Fixes #255

The new release process is:

1. `runhaskell ./bootstrap.hs`. This replaces `.y` and `.ly` files with `.hs` files, which applies to:
    * `packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly`
    * `packages/frontend/src/Happy/Frontend/AttrGrammar/Parser.ly`
2. `cabal v2-sdist all`

This results in the following tarballs:

```
dist-newstyle/sdist/happy-backend-lalr-2.0.tar.gz
dist-newstyle/sdist/happy-grammar-2.0.tar.gz
dist-newstyle/sdist/happy-tabular-2.0.tar.gz
dist-newstyle/sdist/happy-backend-glr-2.0.tar.gz
dist-newstyle/sdist/happy-codegen-common-2.0.tar.gz
dist-newstyle/sdist/happy-frontend-2.0.tar.gz
dist-newstyle/sdist/happy-2.0.tar.gz
```

Thanks to the `./bootstrap.hs` step, the `happy-frontend-2.0.tar.gz` tarball contains `*.hs` files instead of `Bootstrapped.ly` and `Parser.ly`. This should fix the issues that the users of `1.21.0` encountered.

The bump to `2.0` is motivated by the split into packages. I believe it's a major change that enables the use of `happy` as a library, so it deserves a major version bump. It does **not** indicate a breaking change.