### PR TITLE
Draft: Introduce new `%error` handler mode and `catch` for resumable parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist-newstyle
 cabal-dev
 .cabal-sandbox
 cabal.sandbox.config
+cabal.project.local
 .*.swp
 .*.swo
 /.vscode/
+packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.hs
+packages/frontend/src/Happy/Frontend/AttrGrammar/Parser.hs

--- a/happy.cabal
+++ b/happy.cabal
@@ -151,7 +151,7 @@ executable happy
                  happy-backend-glr == 2.0
 
   default-language: Haskell98
-  default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns
+  default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns, PatternGuards
   ghc-options: -Wall
   other-modules:
         Paths_happy

--- a/packages/backend-glr/src/Happy/Backend/GLR/ProduceCode.lhs
+++ b/packages/backend-glr/src/Happy/Backend/GLR/ProduceCode.lhs
@@ -307,6 +307,8 @@ It also shares identical reduction values as CAFs
 >   mkLine state (symInt,action)
 >    | symInt == errorTok       -- skip error productions
 >    = ""                       -- NB see ProduceCode's handling of these
+>    | symInt == catchTok       -- skip error productions
+>    = ""                       -- NB see ProduceCode's handling of these
 >    | otherwise
 >    = case action of
 >       LR'Fail     -> ""

--- a/packages/backend-lalr/data/HappyTemplate.hs
+++ b/packages/backend-lalr/data/HappyTemplate.hs
@@ -46,16 +46,18 @@ data Happy_IntList = HappyCons FAST_INT Happy_IntList
 
 #if defined(HAPPY_ARRAY)
 #  define ERROR_TOK ILIT(0)
+#  define CATCH_TOK ILIT(1)
 #  define DO_ACTION(state,i,tk,sts,stk) happyDoAction i tk state sts (stk)
 #  define HAPPYSTATE(i) (i)
 #  define GOTO(action) happyGoto
-#  define IF_ARRAYS(x) (x)
+#  define IF_ARRAY(x) (x)
 #else
 #  define ERROR_TOK ILIT(1)
+#  define CATCH_TOK ILIT(2)
 #  define DO_ACTION(state,i,tk,sts,stk) state i i tk HAPPYSTATE(state) sts (stk)
 #  define HAPPYSTATE(i) (HappyState (i))
 #  define GOTO(action) action
-#  define IF_ARRAYS(x)
+#  define IF_ARRAY(x)
 #endif
 
 #if defined(HAPPY_COERCE)
@@ -97,39 +99,60 @@ happyParse start_state = happyNewToken start_state notHappyAtAll notHappyAtAll
 happyAccept ERROR_TOK tk st sts (_ `HappyStk` ans `HappyStk` _) =
         happyReturn1 ans
 happyAccept j tk st sts (HappyStk ans _) =
-        IF_GHC(happyTcHack j IF_ARRAYS(happyTcHack st)) (happyReturn1 ans)
+        IF_GHC(happyTcHack j IF_ARRAY(happyTcHack st)) (happyReturn1 ans)
 
 -----------------------------------------------------------------------------
 -- Arrays only: do the next action
 
 #if defined(HAPPY_ARRAY)
 
-happyDoAction i tk st
-        = DEBUG_TRACE("state: " ++ show IBOX(st) ++
-                      ",\ttoken: " ++ show IBOX(i) ++
-                      ",\taction: ")
-          case action of
-                ILIT(0)           -> DEBUG_TRACE("fail.\n")
-                                     happyFail (happyExpListPerState (IBOX(st) :: Prelude.Int)) i tk st
-                ILIT(-1)          -> DEBUG_TRACE("accept.\n")
-                                     happyAccept i tk st
-                n | LT(n,(ILIT(0) :: FAST_INT)) -> DEBUG_TRACE("reduce (rule " ++ show rule
-                                                               ++ ")")
-                                                   (happyReduceArr Happy_Data_Array.! rule) i tk st
-                                                   where rule = IBOX(NEGATE(PLUS(n,(ILIT(1) :: FAST_INT))))
-                n                 -> DEBUG_TRACE("shift, enter state "
-                                                 ++ show IBOX(new_state)
-                                                 ++ "\n")
-                                     happyShift new_state i tk st
-                                     where new_state = MINUS(n,(ILIT(1) :: FAST_INT))
-   where off    = happyAdjustOffset (indexShortOffAddr happyActOffsets st)
-         off_i  = PLUS(off, i)
-         check  = if GTE(off_i,(ILIT(0) :: FAST_INT))
-                  then EQ(indexShortOffAddr happyCheck off_i, i)
-                  else Prelude.False
-         action
-          | check     = indexShortOffAddr happyTable off_i
-          | Prelude.otherwise = indexShortOffAddr happyDefActions st
+happyDoAction i tk st =
+  DEBUG_TRACE("state: " ++ show IBOX(st) ++
+              ",\ttoken: " ++ show IBOX(i) ++
+              ",\taction: ")
+  case happyDecodeAction (happyNextAction i st) of
+    HappyFail   -> DEBUG_TRACE("failing.\n")
+                   happyFail st i tk st
+    HappyAccept -> DEBUG_TRACE("accept.\n")
+                   happyAccept i tk st
+    HappyReduce rule -> DEBUG_TRACE("reduce (rule " ++ show IBOX(rule) ++ ")")
+                        (happyReduceArr Happy_Data_Array.! IBOX(rule)) i tk st
+    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " ++ show IBOX(new_state) ++ "\n")
+                             happyShift new_state i tk st
+
+{-# INLINE happyNextAction #-}
+happyNextAction i st = case happyIndexActionTable i st of
+  Just (IBOX(act)) -> act
+  Nothing          -> indexShortOffAddr happyDefActions st
+
+{-# INLINE happyIndexActionTable #-}
+happyIndexActionTable i st
+  | GTE(off,ILIT(0)), EQ(indexShortOffAddr happyCheck off, i)
+  = Prelude.Just (IBOX(indexShortOffAddr happyTable off))
+  | otherwise
+  = Prelude.Nothing
+  where
+    off = PLUS(happyAdjustOffset (indexShortOffAddr happyActOffsets st), i)
+
+data HappyAction
+  = HappyFail
+  | HappyAccept
+  | HappyReduce FAST_INT -- rule number
+  | HappyShift FAST_INT  -- new state
+
+{-# INLINE happyDecodeAction #-}
+happyDecodeAction ILIT(0)  = HappyFail
+happyDecodeAction ILIT(-1) = HappyAccept
+happyDecodeAction action
+  | LT(action,ILIT(0))
+  = HappyReduce NEGATE(PLUS(action,ILIT(1)))
+  | otherwise
+  = HappyShift MINUS(action,ILIT(1))
+
+{-# INLINE happyIndexGotoTable #-}
+happyIndexGotoTable nt st = indexShortOffAddr happyTable off
+  where
+    off = PLUS(happyAdjustOffset (indexShortOffAddr happyGotoOffsets st), nt)
 
 #endif /* HAPPY_ARRAY */
 
@@ -181,74 +204,46 @@ newtype HappyState b c = HappyState
 
 happyShift new_state ERROR_TOK tk st sts stk@(x `HappyStk` _) =
      let i = GET_ERROR_TOKEN(x) in
---     trace "shifting the error token" $
+     DEBUG_TRACE("shifting the error token")
      DO_ACTION(new_state,i,tk,CONS(st,sts),stk)
-     -- TODO: When `i` would enter error recovery again, we should instead
-     -- discard input until the lookahead is acceptable. Perhaps this is
-     -- simplest to implement in CodeGen for productions using `error`;
-     -- there we know the context and can implement local shift+discard actions.
-     -- still need to remember parser-defined error site, though.
-
 happyShift new_state i tk st sts stk =
      happyNewToken new_state CONS(st,sts) (MK_TOKEN(tk)`HappyStk`stk)
 
 -- happyReduce is specialised for the common cases.
 
-happySpecReduce_0 i fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
-        -- SG: I'm very doubtful that passing [] ("no token expected here")
-        --     as the first arg to happyFail here and in the following calls is
-        --     correct. I'm not going to touch it for a lack of understanding
-        --     and concerns of of backward compatibility, but
-        --       `happyExpListPerState (IBOX(st) :: Prelude.Int)`
-        --     seems like a good candidate.
 happySpecReduce_0 nt fn j tk st@(HAPPYSTATE(action)) sts stk
      = happySeq fn (GOTO(action) nt j tk st CONS(st,sts) (fn `HappyStk` stk))
 
-happySpecReduce_1 i fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
-happySpecReduce_1 nt fn j tk _ sts@(CONS(st@HAPPYSTATE(action),_)) (v1`HappyStk`stk')
+happySpecReduce_1 nt fn j tk old_st sts@(CONS(st@HAPPYSTATE(action),_)) (v1`HappyStk`stk')
      = let r = fn v1 in
-       happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
+       IF_ARRAY(happyTcHack old_st) happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
-happySpecReduce_2 i fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
-happySpecReduce_2 nt fn j tk _ CONS(_,sts@(CONS(st@HAPPYSTATE(action),_))) (v1`HappyStk`v2`HappyStk`stk')
+happySpecReduce_2 nt fn j tk old_st CONS(_,sts@(CONS(st@HAPPYSTATE(action),_))) (v1`HappyStk`v2`HappyStk`stk')
      = let r = fn v1 v2 in
-       happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
+       IF_ARRAY(happyTcHack old_st) happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
-happySpecReduce_3 i fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
-happySpecReduce_3 nt fn j tk _ CONS(_,CONS(_,sts@(CONS(st@HAPPYSTATE(action),_)))) (v1`HappyStk`v2`HappyStk`v3`HappyStk`stk')
+happySpecReduce_3 nt fn j tk old_st CONS(_,CONS(_,sts@(CONS(st@HAPPYSTATE(action),_)))) (v1`HappyStk`v2`HappyStk`v3`HappyStk`stk')
      = let r = fn v1 v2 v3 in
-       happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
+       IF_ARRAY(happyTcHack old_st) happySeq r (GOTO(action) nt j tk st sts (r `HappyStk` stk'))
 
-happyReduce k i fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
-happyReduce k nt fn j tk st sts stk
-     = case happyDrop MINUS(k,(ILIT(1) :: FAST_INT)) sts of
+happyReduce k nt fn j tk st sts stk =
+      case happyDrop k CONS(st,sts) of
          sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
                 let r = fn stk in  -- it doesn't hurt to always seq here...
                 happyDoSeq r (GOTO(action) nt j tk st1 sts1 r)
 
-happyMonadReduce k nt fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
 happyMonadReduce k nt fn j tk st sts stk =
       case happyDrop k CONS(st,sts) of
         sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
           let drop_stk = happyDropStk k stk in
           happyThen1 (fn stk tk) (\r -> GOTO(action) nt j tk st1 sts1 (r `HappyStk` drop_stk))
 
-happyMonad2Reduce k nt fn ERROR_TOK tk st sts stk
-     = happyFail [] ERROR_TOK tk st sts stk
 happyMonad2Reduce k nt fn j tk st sts stk =
-      case happyDrop k CONS(st,sts) of
+      j `happyTcHack` case happyDrop k CONS(st,sts) of
         sts1@(CONS(st1@HAPPYSTATE(action),_)) ->
          let drop_stk = happyDropStk k stk
 #if defined(HAPPY_ARRAY)
-             off = happyAdjustOffset (indexShortOffAddr happyGotoOffsets st1)
-             off_i = PLUS(off, nt)
-             new_state = indexShortOffAddr happyTable off_i
+             new_state = happyIndexGotoTable nt st1
 #else
              _ = nt :: FAST_INT
              new_state = action
@@ -268,10 +263,7 @@ happyDropStk n (x `HappyStk` xs) = happyDropStk MINUS(n,(ILIT(1)::FAST_INT)) xs
 #if defined(HAPPY_ARRAY)
 happyGoto nt j tk st =
    DEBUG_TRACE(", goto state " ++ show IBOX(new_state) ++ "\n")
-   happyDoAction j tk new_state
-   where off = happyAdjustOffset (indexShortOffAddr happyGotoOffsets st)
-         off_i = PLUS(off, nt)
-         new_state = indexShortOffAddr happyTable off_i
+   happyDoAction j tk new_state where new_state = (happyIndexGotoTable nt st)
 #else
 happyGoto action j tk st = action j j tk (HappyState action)
 #endif
@@ -285,39 +277,84 @@ happyGoto action j tk st = action j j tk (HappyState action)
 --  1. Fixup: Try to see if there is an action for the error token (`errorTok`,
 --     which is ERROR_TOK). If there is, do *not* emit an error and pretend
 --     instead that an `errorTok` was inserted.
---     When there is no `errorTok` action, call `happyErro` and enter error
---     resumption mode.
---  2. Error resumption mode: After `happyError` was called TODO: happyError is fatal.
---     Perhaps we should introduce a new `happyAddError`?
---     Current plan: New %resumptive declaration for specifying the two funs,
---     mutually exclusive with %error.
+--     When there is no `errorTok` action, call the error handler
+--     (e.g., `happyError`) with the resumption continuation `happyResume`.
+--  2. Error resumption mode: If the error handler wants to resume parsing in
+--     order to report multiple parse errors, it will call the resumption
+--     continuation (of result type `P (Maybe a)`).
+--     In the absence of the %resumptive declaration, this resumption will
+--     always (do a bit of work, and) `return Nothing`.
+--     In the presence of the %resumptive declaration, the grammar author
+--     can use the special `catch` terminal to declare where parsing should
+--     resume after an error.
+--     E.g., if `stmt : expr ';' | catch ';'` then the resumption will
 --
---     This is what usually is associated with `error`
---     in `bison` or `menhir`. Since `error` is used for the Fixup mechanism (1)
---     above, we call the corresponding token `catch`.
---     In particular, `catch` will never *omit* calls to `happyFail`.
+--       (a) Pop off the state stack until it finds an item
+--             `stmt -> . catch ';'`.
+--           Then, it will push a `catchTok` onto the stack, perform a shift and
+--           end up in item `stmt -> catch . ';'`.
+--       (b) Discard tokens from the lexer until it finds ';'.
+--           (In general, it will discard until the lookahead has a non-default
+--           action in the matches a token that applies
+--           in the situation `P -> α catch . β`, where β might empty.)
+--
+-- The `catch` resumption mechanism (2) is what usually is associated with
+-- `error` in `bison` or `menhir`. Since `error` is used for the Fixup mechanism
+-- (1) above, we call the corresponding token `catch`.
 
--- parse error if we are in recovery and reached the end of the state stack
-happyFail explist ERROR_TOK tk old_st _ stk@(x `HappyStk` _) =
-     let i = GET_ERROR_TOKEN(x) in
---      trace "failing" $
-        happyError_ explist i tk noResumption_
+-- Enter error Fixup: generate an error token,
+--                    save the old token and carry on.
+--                    When a `happyShift` accepts, we will pop off the error
+--                    token to resume parsing with the current lookahead `i`.
+happyTryFixup i tk HAPPYSTATE(action) sts stk =
+  DEBUG_TRACE("entering `error` fixup.\n")
+  DO_ACTION(action,ERROR_TOK,tk,sts, MK_ERROR_TOKEN(i) `HappyStk` stk)
+  -- NB: `happyShift` will simply pop the error token and carry on with
+  --     `tk`. Hence we don't change `tk` in the call here
 
-{-
--- discard a state
-happyFail explist ERROR_TOK tk old_st CONS(HAPPYSTATE(action),sts)
-                                                (saved_tok `HappyStk` _ `HappyStk` stk) =
---      trace ("discarding state, depth " ++ show (length stk))  $
-        DO_ACTION(action,ERROR_TOK,tk,sts,(saved_tok`HappyStk`stk))
--}
+-- parse error if we are in fixup and fail again
+happyFixupFailed state_num tk st sts (x `HappyStk` stk) =
+  let i = GET_ERROR_TOKEN(x) in
+  DEBUG_TRACE("`error` fixup failed.\n")
+#if defined(HAPPY_ARRAY)
+  -- TODO: Walk the stack instead of looking only at the top state_num
+  happyError_ i tk (happyExpListPerState (IBOX(state_num))) (happyResume i tk st sts stk)
+#else
+  happyError_ i tk (happyExpListPerState (IBOX(state_num))) (happyResume i tk st sts stk)
+#endif
 
--- Enter error recovery: generate an error token,
---                       save the old token and carry on.
---                       When a `happyShift` accepts, we will pop off the error
---                       token to resume parsing with the current lookahead `i`.
-happyFail explist i tk HAPPYSTATE(action) sts stk =
---      trace "entering error recovery" $
-        DO_ACTION(action,ERROR_TOK,tk,sts, MK_ERROR_TOKEN(i) `HappyStk` stk)
+happyFail state_num ERROR_TOK = happyFixupFailed state_num
+happyFail _         i         = happyTryFixup i
+
+#if defined(HAPPY_ARRAY)
+happyResume i tk st sts stk = pop_items st sts stk
+  where
+    pop_items st sts stk
+      | HappyShift new_state <- happyDecodeAction (happyNextAction CATCH_TOK st)
+      = DEBUG_TRACE("shifting catch token " ++ show IBOX(st) ++ " -> " ++ show IBOX(new_state) ++ "\n")
+        discard_input_until_exp i tk new_state CONS(st,sts) (MK_ERROR_TOKEN(i) `HappyStk` stk)
+      | DEBUG_TRACE("can't shift catch in " ++ show IBOX(st) ++ ", ") True
+      , IBOX(n_starts) <- happy_n_starts, LT(st, n_starts)
+      = DEBUG_TRACE("because it is a start state. no resumption.\n")
+        happyReturn1 Nothing
+      | CONS(st1,sts1) <- sts, _ `HappyStk` stk1 <- stk
+      = DEBUG_TRACE("discarding.\n")
+        pop_items st1 sts1 stk1
+--    discard_input_until_exp :: Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int#  -> _
+    discard_input_until_exp i tk st sts stk
+      | HappyFail <- happyDecodeAction (happyNextAction i st)
+      = DEBUG_TRACE("discard token in state " ++ show IBOX(st) ++ ": " ++ show IBOX(i) ++ "\n")
+        happyLex (\_eof_tk -> happyReturn1 Nothing)
+                 (\i tk -> discard_input_until_exp i tk st sts stk) -- not eof
+      | otherwise
+      = DEBUG_TRACE("found expected token in state " ++ show IBOX(st) ++ ": " ++ show IBOX(i) ++ "\n")
+        happyFmap1 (\a -> a `happySeq` Just a)
+                   (DO_ACTION(st,i,tk,sts,stk))
+#else
+happyResume (i :: FAST_INT) tk st sts stk = happyReturn1 Nothing
+#endif
+
+
 -- Internal happy errors:
 
 notHappyAtAll :: a
@@ -330,6 +367,8 @@ notHappyAtAll = Prelude.error "Internal Happy error\n"
 happyTcHack :: Happy_GHC_Exts.Int# -> a -> a
 happyTcHack x y = y
 {-# INLINE happyTcHack #-}
+#else
+happyTcHack x y = y
 #endif
 
 -----------------------------------------------------------------------------

--- a/packages/backend-lalr/src/Happy/Backend/LALR.hs
+++ b/packages/backend-lalr/src/Happy/Backend/LALR.hs
@@ -19,16 +19,18 @@ magicFilter magicName = case magicName of
       in filter_output
 
 importsToInject :: Bool -> Bool -> String
-importsToInject ghc debug = concat ["\n", import_array, import_bits, glaexts_import, debug_imports, applicative_imports]
+importsToInject ghc debug = concat ["\n", import_array, import_list, import_bits, glaexts_import, debug_imports, applicative_imports]
     where
-      glaexts_import | ghc       = import_glaexts
+      glaexts_import | ghc       = import_glaexts ++ import_ghcstack
                      | otherwise = ""
       debug_imports  | debug     = import_debug
                      | otherwise = ""
       applicative_imports        = import_applicative
 
       import_glaexts     = "import qualified GHC.Exts as Happy_GHC_Exts\n"
+      import_ghcstack    = "import qualified GHC.Stack as Happy_GHC_Stack\n"
       import_array       = "import qualified Data.Array as Happy_Data_Array\n"
+      import_list        = "import qualified Data.List as Happy_Data_List\n"
       import_bits        = "import qualified Data.Bits as Bits\n"
       import_debug       = "import qualified System.IO as Happy_System_IO\n" ++
                            "import qualified System.IO.Unsafe as Happy_System_IO_Unsafe\n" ++

--- a/packages/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
+++ b/packages/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
@@ -1187,10 +1187,11 @@ See notes under "Action Tables" above for some subtleties in this function.
 >                            f (t, LR'Shift _ _ ) = [t - fst token_names_bound]
 >                            f (_, _) = []
 >
->        -- adjust terminals by -(fst_term+1), so they start at 1 (error is 0).
+>        -- adjust terminals by -(fst_term+2), so they start at 2 (error is 0, catch is 1).
 >        --  (see ARRAY_NOTES)
 >        adjust token | token == errorTok = 0
->                     | otherwise         = token - fst_term + 1
+>                     | token == catchTok = 1
+>                     | otherwise         = token - fst_term + 2
 >
 >        mkActVals assocs' default_act =
 >                [ (adjust token, actionVal act)

--- a/packages/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
+++ b/packages/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
@@ -4,6 +4,7 @@ The code generator.
 (c) 1993-2001 Andy Gill, Simon Marlow
 -----------------------------------------------------------------------------
 
+> {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 > module Happy.Backend.LALR.ProduceCode (produceParser) where
 
 > import Paths_happy_backend_lalr  ( version )

--- a/packages/codegen-common/src/Happy/CodeGen/Common/Options.lhs
+++ b/packages/codegen-common/src/Happy/CodeGen/Common/Options.lhs
@@ -21,5 +21,11 @@ The CommonOptions data type.
 >               expect            :: Maybe Int,
 >               lexer             :: Maybe (String,String),
 >               error_handler     :: Maybe String,
->               error_sig         :: ErrorHandlerType
+>               error_sig         :: ErrorHandlerType,
+>                 -- ^ ErrorHandlerTypExpList: error handler expects a
+>                 --   `[String]` as first arg with the pretty-printed expected
+>                 --   tokens
+>               error_resumptive  :: Bool
+>                 -- ^ `True` => The error handler expects a `resume`
+>                 -- continuation as last argument.
 >       }

--- a/packages/codegen-common/src/Happy/CodeGen/Common/Options.lhs
+++ b/packages/codegen-common/src/Happy/CodeGen/Common/Options.lhs
@@ -5,14 +5,20 @@ The CommonOptions data type.
 -----------------------------------------------------------------------------
 
 > module Happy.CodeGen.Common.Options (
->       ErrorHandlerType(..),
->       CommonOptions(..)
+>       ErrorHandlerInfo(..), CommonOptions(..)
 >       ) where
 
-> data ErrorHandlerType
->   = ErrorHandlerTypeDefault
->   | ErrorHandlerTypeExpList
-
+> data ErrorHandlerInfo
+>   = DefaultErrorHandler
+>   -- ^ Default handler `happyError`.
+>   | CustomErrorHandler String
+>   -- ^ Call this handler on error.
+>   | ResumptiveErrorHandler String {- abort -} String {- addMessage -}
+>   -- ^ `ResumptiveErrorHandler abort reportError`:
+>   --   Calls non-fatal `reportError ... resume` with resumption `resume` to
+>   --   get more errors, ultimately failing with `abort` when parse can't be
+>   --   resumed.
+>
 > data CommonOptions
 >       = CommonOptions {
 >               token_type        :: String,
@@ -20,12 +26,8 @@ The CommonOptions data type.
 >               monad             :: (Bool,String,String,String,String),
 >               expect            :: Maybe Int,
 >               lexer             :: Maybe (String,String),
->               error_handler     :: Maybe String,
->               error_sig         :: ErrorHandlerType,
->                 -- ^ ErrorHandlerTypExpList: error handler expects a
->                 --   `[String]` as first arg with the pretty-printed expected
->                 --   tokens
->               error_resumptive  :: Bool
->                 -- ^ `True` => The error handler expects a `resume`
->                 -- continuation as last argument.
+>               error_handler     :: ErrorHandlerInfo,
+>               error_expected    :: Bool
+>                 -- ^ Error handler expects a `[String]` as arg after current
+>                 -- token carrying the pretty-printed expected tokens.
 >       }

--- a/packages/frontend/happy-frontend.cabal
+++ b/packages/frontend/happy-frontend.cabal
@@ -61,7 +61,7 @@ library
                        happy-grammar == 2.0
 
   default-language:    Haskell98
-  default-extensions:  CPP, MagicHash, FlexibleContexts
+  default-extensions:  CPP, MagicHash, FlexibleContexts, PatternGuards
   ghc-options: -Wall
   other-modules:
         Happy.Frontend.ParseMonad

--- a/packages/frontend/src/Happy/Frontend/AbsSyn.lhs
+++ b/packages/frontend/src/Happy/Frontend/AbsSyn.lhs
@@ -11,7 +11,7 @@ Here is the abstract syntax of the language we parse.
 >       AbsSyn(..), Directive(..),
 >       getTokenType, getTokenSpec, getParserNames, getLexer,
 >       getImportedIdentity, getMonad, getError,
->       getPrios, getPrioNames, getExpect, getErrorHandlerType,
+>       getPrios, getPrioNames, getExpect, getErrorHandlerType, getErrorResumptive,
 >       getAttributes, getAttributetype,
 >       Rule(..), Prod(..), Term(..), Prec(..)
 >  ) where
@@ -66,7 +66,6 @@ generate some error messages.
 >       | TokenSpec     [(a,String)]            -- %token
 >       | TokenName     String (Maybe String) Bool -- %name/%partial (True <=> %partial)
 >       | TokenLexer    String String           -- %lexer
->       | TokenErrorHandlerType String          -- %errorhandlertype
 >       | TokenImportedIdentity                                 -- %importedidentity
 >       | TokenMonad    String String String String -- %monad
 >       | TokenNonassoc [String]                -- %nonassoc
@@ -74,6 +73,8 @@ generate some error messages.
 >       | TokenLeft     [String]                -- %left
 >       | TokenExpect   Int                     -- %expect
 >       | TokenError    String                  -- %error
+>       | TokenErrorHandlerType String          -- %errorhandlertype
+>       | TokenErrorResumptive                  -- %resumptive
 >       | TokenAttributetype String             -- %attributetype
 >       | TokenAttribute String String          -- %attribute
 >   deriving Show
@@ -150,6 +151,9 @@ generate some error messages.
 >                        _ -> error "unsupported %errorhandlertype value"
 >               []  -> ErrorHandlerTypeDefault
 >               _   -> error "multiple errorhandlertype directives"
+
+> getErrorResumptive :: [Directive t] -> Bool
+> getErrorResumptive ds = not (null [ () | TokenErrorResumptive <- ds ])
 
 > getAttributes :: [Directive t] -> [(String, String)]
 > getAttributes ds

--- a/packages/frontend/src/Happy/Frontend/Lexer.lhs
+++ b/packages/frontend/src/Happy/Frontend/Lexer.lhs
@@ -104,44 +104,47 @@ followed by a special identifier.
 > lexPercent :: (Token -> Pfunc a) -> [Char] -> Int -> ParseResult a
 > lexPercent cont s = case s of
 >       '%':rest -> cont (TokenKW TokDoublePercent) rest
->       't':'o':'k':'e':'n':'t':'y':'p':'e':rest ->
+>       't':'o':'k':'e':'n':'t':'y':'p':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_TokenType) rest
->       't':'o':'k':'e':'n':rest ->
+>       't':'o':'k':'e':'n':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Token) rest
->       'n':'a':'m':'e':rest ->
+>       'n':'a':'m':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Name) rest
->       'p':'a':'r':'t':'i':'a':'l':rest ->
+>       'p':'a':'r':'t':'i':'a':'l':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Partial) rest
->       'i':'m':'p':'o':'r':'t':'e':'d':'i':'d':'e':'n':'t':'i':'t':'y':rest ->
+>       'i':'m':'p':'o':'r':'t':'e':'d':'i':'d':'e':'n':'t':'i':'t':'y':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_ImportedIdentity) rest
->       'm':'o':'n':'a':'d':rest ->
+>       'm':'o':'n':'a':'d':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Monad) rest
->       'l':'e':'x':'e':'r':rest ->
+>       'l':'e':'x':'e':'r':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Lexer) rest
->       'n':'o':'n':'a':'s':'s':'o':'c':rest ->
+>       'n':'o':'n':'a':'s':'s':'o':'c':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Nonassoc) rest
->       'l':'e':'f':'t':rest ->
+>       'l':'e':'f':'t':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Left) rest
->       'r':'i':'g':'h':'t':rest ->
+>       'r':'i':'g':'h':'t':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Right) rest
->       'p':'r':'e':'c':rest ->
+>       'p':'r':'e':'c':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Prec) rest
->       's':'h':'i':'f':'t':rest ->
+>       's':'h':'i':'f':'t':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Shift) rest
->       'e':'x':'p':'e':'c':'t':rest ->
+>       'e':'x':'p':'e':'c':'t':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Expect) rest
->       'e':'r':'r':'o':'r':'h':'a':'n':'d':'l':'e':'r':'t':'y':'p':'e':rest ->
+>       'e':'r':'r':'o':'r':'h':'a':'n':'d':'l':'e':'r':'t':'y':'p':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_ErrorHandlerType) rest
->       'e':'r':'r':'o':'r':'r':'e':'s':'u':'m':'t':'i':'v':'e':rest ->
+>       'e':'r':'r':'o':'r':'r':'e':'s':'u':'m':'p':'t':'i':'v':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_ErrorResumptive) rest
->       'e':'r':'r':'o':'r':rest ->
+>       'e':'r':'r':'o':'r':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Error) rest
->       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest ->
+>       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Attributetype) rest
->       'a':'t':'t':'r':'i':'b':'u':'t':'e':rest ->
+>       'a':'t':'t':'r':'i':'b':'u':'t':'e':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Attribute) rest
 >       _ -> lexError ("unrecognised directive: %" ++
 >                               takeWhile (not.isSpace) s) s
+>    where
+>       end_of_id (c:_) = not (isAlphaNum c)
+>       end_of_id []    = True
 
 > lexColon :: (Token -> Pfunc a) -> [Char] -> Int -> ParseResult a
 > lexColon cont (':':rest) = cont (TokenKW TokDoubleColon) rest

--- a/packages/frontend/src/Happy/Frontend/Lexer.lhs
+++ b/packages/frontend/src/Happy/Frontend/Lexer.lhs
@@ -37,7 +37,6 @@ The lexer.
 >       | TokSpecId_Token       -- %token
 >       | TokSpecId_Name        -- %name
 >       | TokSpecId_Partial     -- %partial
->       | TokSpecId_ErrorHandlerType    -- %errorhandlertype
 >       | TokSpecId_Lexer       -- %lexer
 >       | TokSpecId_ImportedIdentity -- %importedidentity
 >       | TokSpecId_Monad       -- %monad
@@ -48,6 +47,8 @@ The lexer.
 >       | TokSpecId_Shift       -- %shift
 >       | TokSpecId_Expect      -- %expect
 >       | TokSpecId_Error       -- %error
+>       | TokSpecId_ErrorHandlerType -- %errorhandlertype
+>       | TokSpecId_ErrorResumptive  -- %errorresumptive
 >       | TokSpecId_Attributetype -- %attributetype
 >       | TokSpecId_Attribute   -- %attribute
 >       | TokCodeQuote          -- stuff inside { .. }
@@ -131,6 +132,8 @@ followed by a special identifier.
 >               cont (TokenKW TokSpecId_Expect) rest
 >       'e':'r':'r':'o':'r':'h':'a':'n':'d':'l':'e':'r':'t':'y':'p':'e':rest ->
 >               cont (TokenKW TokSpecId_ErrorHandlerType) rest
+>       'e':'r':'r':'o':'r':'r':'e':'s':'u':'m':'t':'i':'v':'e':rest ->
+>               cont (TokenKW TokSpecId_ErrorResumptive) rest
 >       'e':'r':'r':'o':'r':rest ->
 >               cont (TokenKW TokSpecId_Error) rest
 >       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest ->

--- a/packages/frontend/src/Happy/Frontend/Lexer.lhs
+++ b/packages/frontend/src/Happy/Frontend/Lexer.lhs
@@ -47,8 +47,7 @@ The lexer.
 >       | TokSpecId_Shift       -- %shift
 >       | TokSpecId_Expect      -- %expect
 >       | TokSpecId_Error       -- %error
->       | TokSpecId_ErrorHandlerType -- %errorhandlertype
->       | TokSpecId_ErrorResumptive  -- %errorresumptive
+>       | TokSpecId_ErrorExpected -- %error.expected
 >       | TokSpecId_Attributetype -- %attributetype
 >       | TokSpecId_Attribute   -- %attribute
 >       | TokCodeQuote          -- stuff inside { .. }
@@ -130,10 +129,8 @@ followed by a special identifier.
 >               cont (TokenKW TokSpecId_Shift) rest
 >       'e':'x':'p':'e':'c':'t':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Expect) rest
->       'e':'r':'r':'o':'r':'h':'a':'n':'d':'l':'e':'r':'t':'y':'p':'e':rest | end_of_id rest ->
->               cont (TokenKW TokSpecId_ErrorHandlerType) rest
->       'e':'r':'r':'o':'r':'r':'e':'s':'u':'m':'p':'t':'i':'v':'e':rest | end_of_id rest ->
->               cont (TokenKW TokSpecId_ErrorResumptive) rest
+>       'e':'r':'r':'o':'r':'.':'e':'x':'p':'e':'c':'t':'e':'d':rest | end_of_id rest ->
+>               cont (TokenKW TokSpecId_ErrorExpected) rest
 >       'e':'r':'r':'o':'r':rest | end_of_id rest ->
 >               cont (TokenKW TokSpecId_Error) rest
 >       'a':'t':'t':'r':'i':'b':'u':'t':'e':'t':'y':'p':'e':rest | end_of_id rest ->

--- a/packages/frontend/src/Happy/Frontend/Mangler.lhs
+++ b/packages/frontend/src/Happy/Frontend/Mangler.lhs
@@ -69,6 +69,7 @@ This bit is a real mess, mainly because of the error message support.
 >       starts'     = case getParserNames dirs of
 >                       [] -> [TokenName "happyParse" Nothing False]
 >                       ns -> ns
+>       error_resumptive' = getErrorResumptive dirs
 >
 >       start_strs  = [ startName++'_':p  | (TokenName p _ _) <- starts' ]
 
@@ -87,7 +88,7 @@ Build up a mapping from name values to strings.
 >             case lookupName str' of
 >                [a]   -> return a
 >                []    -> do addErr ("unknown identifier '" ++ str' ++ "'")
->                            return errorTok
+>                            return errorTok -- SG: What a confusing use of errorTok.. Use dummyTok?
 >                (a:_) -> do addErr ("multiple use of '" ++ str' ++ "'")
 >                            return a
 
@@ -249,6 +250,7 @@ Get the token specs in terms of Names.
 >               lexer             = getLexer dirs,
 >               error_handler     = getError dirs,
 >               error_sig         = getErrorHandlerType dirs,
+>               error_resumptive  = error_resumptive',
 >               token_type        = getTokenType dirs,
 >               expect            = getExpect dirs
 >       })

--- a/packages/frontend/src/Happy/Frontend/Mangler.lhs
+++ b/packages/frontend/src/Happy/Frontend/Mangler.lhs
@@ -76,13 +76,17 @@ This bit is a real mess, mainly because of the error message support.
 Build up a mapping from name values to strings.
 
 >       name_env = (errorTok, errorName) :
+>                  (catchTok, catchName) :
 >                  (dummyTok, dummyName) :
 >                  zip start_names    start_strs ++
 >                  zip nonterm_names  nonterm_strs ++
 >                  zip terminal_names terminal_strs
 
 >       lookupName :: String -> [Name]
->       lookupName n = [ t | (t,r) <- name_env, r == n ]
+>       lookupName n = [ t | (t,r) <- name_env, r == n
+>                          , t /= catchTok || error_resumptive' ]
+>                            -- hide catchName unless %errorresumptive is active
+>                            -- issue93.y uses catch as a nonterminal, we should not steal it
 
 >       mapToName str' =
 >             case lookupName str' of
@@ -230,7 +234,7 @@ Get the token specs in terms of Names.
 >               lookupProdNo      = (prod_array !),
 >               lookupProdsOfName = lookup_prods,
 >               token_specs       = tokspec,
->               terminals         = errorTok : terminal_names,
+>               terminals         = errorTok : catchTok : terminal_names,
 >               non_terminals     = start_names ++ nonterm_names,
 >                                       -- INCLUDES the %start tokens
 >               starts            = zip4 parser_names start_names start_toks

--- a/packages/frontend/src/Happy/Frontend/Mangler.lhs
+++ b/packages/frontend/src/Happy/Frontend/Mangler.lhs
@@ -69,7 +69,8 @@ This bit is a real mess, mainly because of the error message support.
 >       starts'     = case getParserNames dirs of
 >                       [] -> [TokenName "happyParse" Nothing False]
 >                       ns -> ns
->       error_resumptive' = getErrorResumptive dirs
+>       error_resumptive | ResumptiveErrorHandler{} <- getError dirs = True
+>                        | otherwise                                 = False
 >
 >       start_strs  = [ startName++'_':p  | (TokenName p _ _) <- starts' ]
 
@@ -84,7 +85,7 @@ Build up a mapping from name values to strings.
 
 >       lookupName :: String -> [Name]
 >       lookupName n = [ t | (t,r) <- name_env, r == n
->                          , t /= catchTok || error_resumptive' ]
+>                          , t /= catchTok || error_resumptive ]
 >                            -- hide catchName unless %errorresumptive is active
 >                            -- issue93.y uses catch as a nonterminal, we should not steal it
 
@@ -253,8 +254,7 @@ Get the token specs in terms of Names.
 >               monad             = getMonad dirs,
 >               lexer             = getLexer dirs,
 >               error_handler     = getError dirs,
->               error_sig         = getErrorHandlerType dirs,
->               error_resumptive  = error_resumptive',
+>               error_expected    = getErrorHandlerExpectedList dirs,
 >               token_type        = getTokenType dirs,
 >               expect            = getExpect dirs
 >       })

--- a/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
+++ b/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
@@ -33,8 +33,7 @@ The parser.
 >       spec_shift      { TokenKW      TokSpecId_Shift }
 >       spec_expect     { TokenKW      TokSpecId_Expect }
 >       spec_error      { TokenKW      TokSpecId_Error }
->       spec_errorhandlertype   { TokenKW      TokSpecId_ErrorHandlerType }
->       spec_errorresumptive { TokenKW      TokSpecId_ErrorResumptive }
+>       spec_errorexpected  { TokenKW      TokSpecId_ErrorExpected }
 >       spec_attribute  { TokenKW      TokSpecId_Attribute }
 >       spec_attributetype      { TokenKW      TokSpecId_Attributetype }
 >       code            { TokenInfo $$ TokCodeQuote }
@@ -124,9 +123,8 @@ The parser.
 >       | spec_right ids                { TokenRight $2 }
 >       | spec_left ids                 { TokenLeft $2 }
 >       | spec_expect int               { TokenExpect $2 }
->       | spec_error code               { TokenError $2 }
->       | spec_errorhandlertype id      { TokenErrorHandlerType $2 }
->       | spec_errorresumptive          { TokenErrorResumptive }
+>       | spec_error code code          { TokenError $2 $3 }
+>       | spec_errorexpected            { TokenErrorExpected }
 >       | spec_attributetype code       { TokenAttributetype $2 }
 >       | spec_attribute id code        { TokenAttribute $2 $3 }
 

--- a/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
+++ b/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
@@ -34,6 +34,7 @@ The parser.
 >       spec_expect     { TokenKW      TokSpecId_Expect }
 >       spec_error      { TokenKW      TokSpecId_Error }
 >       spec_errorhandlertype   { TokenKW      TokSpecId_ErrorHandlerType }
+>       spec_errorresumptive { TokenKW      TokSpecId_ErrorResumptive }
 >       spec_attribute  { TokenKW      TokSpecId_Attribute }
 >       spec_attributetype      { TokenKW      TokSpecId_Attributetype }
 >       code            { TokenInfo $$ TokCodeQuote }
@@ -104,11 +105,11 @@ The parser.
 >       | spec_shift                    { PrecShift }
 >       |                               { PrecNone }
 
-> tokInfos :: { [Directive String] } 
+> tokInfos :: { [Directive String] }
 >       : tokInfos tokInfo              { $2 : $1 }
 >       | tokInfo                       { [$1] }
 
-> tokInfo :: { Directive String } 
+> tokInfo :: { Directive String }
 >       : spec_tokentype code           { TokenType $2 }
 >       | spec_token tokenSpecs         { TokenSpec $2 }
 >       | spec_name id optStart         { TokenName $2 $3 False }
@@ -124,7 +125,8 @@ The parser.
 >       | spec_left ids                 { TokenLeft $2 }
 >       | spec_expect int               { TokenExpect $2 }
 >       | spec_error code               { TokenError $2 }
->       | spec_errorhandlertype id              { TokenErrorHandlerType $2 }
+>       | spec_errorhandlertype id      { TokenErrorHandlerType $2 }
+>       | spec_errorresumptive          { TokenErrorResumptive }
 >       | spec_attributetype code       { TokenAttributetype $2 }
 >       | spec_attribute id code        { TokenAttribute $2 $3 }
 

--- a/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
+++ b/packages/frontend/src/Happy/Frontend/Parser/Bootstrapped.ly
@@ -123,7 +123,7 @@ The parser.
 >       | spec_right ids                { TokenRight $2 }
 >       | spec_left ids                 { TokenLeft $2 }
 >       | spec_expect int               { TokenExpect $2 }
->       | spec_error code code          { TokenError $2 $3 }
+>       | spec_error code optCode       { TokenError $2 $3 }
 >       | spec_errorexpected            { TokenErrorExpected }
 >       | spec_attributetype code       { TokenAttributetype $2 }
 >       | spec_attribute id code        { TokenAttribute $2 $3 }

--- a/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
+++ b/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
@@ -86,12 +86,15 @@ optTokInfoP = withToken match where
   match (TokenKW TokSpecId_Expect) =
     Consume `andThenJust`
     pure TokenExpect <*> numP
-  match (TokenKW TokSpecId_Error) =
-    Consume `andThenJust`
-    pure TokenError <*> codeP
   match (TokenKW TokSpecId_ErrorHandlerType) =
     Consume `andThenJust`
     pure TokenErrorHandlerType <*> idtP
+  match (TokenKW TokSpecId_ErrorResumptive) =
+    Consume `andThenJust`
+    pure TokenErrorResumptive
+  match (TokenKW TokSpecId_Error) =
+    Consume `andThenJust`
+    pure TokenError <*> codeP
   match (TokenKW TokSpecId_Attributetype) =
     Consume `andThenJust`
     pure TokenAttributetype <*> codeP

--- a/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
+++ b/packages/frontend/src/Happy/Frontend/Parser/Oracle.hs
@@ -86,15 +86,17 @@ optTokInfoP = withToken match where
   match (TokenKW TokSpecId_Expect) =
     Consume `andThenJust`
     pure TokenExpect <*> numP
-  match (TokenKW TokSpecId_ErrorHandlerType) =
+  match (TokenKW TokSpecId_ErrorExpected) =
     Consume `andThenJust`
-    pure TokenErrorHandlerType <*> idtP
-  match (TokenKW TokSpecId_ErrorResumptive) =
-    Consume `andThenJust`
-    pure TokenErrorResumptive
+    pure TokenErrorExpected
   match (TokenKW TokSpecId_Error) =
-    Consume `andThenJust`
-    pure TokenError <*> codeP
+    Consume `andThenJust` do
+      codes <- manyP optCodeP
+      case codes of
+        [c1]             -> return $ TokenError c1 Nothing
+        [c1, c2]         -> return $ TokenError c1 (Just c2)
+        [] -> parseError "Expected a code block"
+        _  -> parseError "Too many code blocks"
   match (TokenKW TokSpecId_Attributetype) =
     Consume `andThenJust`
     pure TokenAttributetype <*> codeP

--- a/packages/grammar/src/Happy/Grammar.lhs
+++ b/packages/grammar/src/Happy/Grammar.lhs
@@ -11,7 +11,8 @@ The Grammar data type.
 >       Priority(..),
 >       Assoc(..),
 >
->       errorName, errorTok, startName, dummyName, firstStartTok, dummyTok,
+>       errorName, errorTok, catchName, catchTok,
+>       startName, dummyName, firstStartTok, dummyTok,
 >       eofName, epsilonTok,
 >
 >       mapDollarDollar
@@ -111,15 +112,17 @@ In normal and GHC-based parsers, these numbers are also used in the
 generated grammar itself, except that the error token is mapped to -1.
 For array-based parsers, see the note in Tabular/LALR.lhs.
 
-> startName, eofName, errorName, dummyName :: String
+> startName, eofName, errorName, catchName, dummyName :: String
 > startName = "%start" -- with a suffix, like %start_1, %start_2 etc.
 > eofName   = "%eof"
 > errorName = "error"
+> catchName = "catch"
 > dummyName = "%dummy"  -- shouldn't occur in the grammar anywhere
 
-> firstStartTok, dummyTok, errorTok, epsilonTok :: Name
-> firstStartTok   = 3
-> dummyTok        = 2
+> firstStartTok, dummyTok, errorTok, catchTok, epsilonTok :: Name
+> firstStartTok   = 4
+> dummyTok        = 3
+> catchTok        = 2
 > errorTok        = 1
 > epsilonTok      = 0
 

--- a/packages/tabular/src/Happy/Tabular.lhs
+++ b/packages/tabular/src/Happy/Tabular.lhs
@@ -64,7 +64,7 @@ Find unused rules and tokens
 >       start_rules      = [ 0 .. (length starts' - 1) ]
 >       used_rules       = start_rules ++
 >                          nub [ r | (_,a) <- actions, r <- extract_reductions a ]
->       used_tokens      = errorTok : eof :
+>       used_tokens      = errorTok : catchTok : eof :
 >                              nub [ t | (t,a) <- actions, is_shift a ]
 >       n_prods          = length productions'
 >       unused_terminals = filter (`notElem` used_tokens) terms

--- a/packages/tabular/src/Happy/Tabular/First.lhs
+++ b/packages/tabular/src/Happy/Tabular/First.lhs
@@ -49,7 +49,7 @@ This will never terminate.
 > getNext fst_term prodNo prodsOfName env =
 >               [ (nm, next nm) | (nm,_) <- env ]
 >    where
->       fn t | t == errorTok || t >= fst_term = Set.singleton t
+>       fn t | t == errorTok || t == catchTok || t >= fst_term = Set.singleton t
 >       fn x = maybe (error "attempted FIRST(e) :-(") id (lookup x env)
 
 >       next :: Name -> NameSet

--- a/packages/tabular/src/Happy/Tabular/LALR.lhs
+++ b/packages/tabular/src/Happy/Tabular/LALR.lhs
@@ -520,7 +520,7 @@ Generate the action table
 
 >       possAction goto _set (Lr1 rule pos la) =
 >          case findRule g rule pos of
->               Just t | t >= fst_term || t == errorTok ->
+>               Just t | t >= fst_term || t == errorTok || t == catchTok ->
 >                       let f j = (t,LR'Shift j p)
 >                           p = maybe No id (lookup t prios)
 >                       in map f $ maybeToList (lookup t goto)

--- a/packages/tabular/src/Happy/Tabular/LALR.lhs
+++ b/packages/tabular/src/Happy/Tabular/LALR.lhs
@@ -5,6 +5,8 @@ Generation of LALR parsing tables.
 (c) 1997-2001 Simon Marlow
 -----------------------------------------------------------------------------
 
+> {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+>
 > module Happy.Tabular.LALR
 >       (genActionTable, genGotoTable, genLR0items, precalcClosure0,
 >        propLookaheads, calcLookaheads, mergeLookaheadInfo, countConflicts,

--- a/tests/issue265.y
+++ b/tests/issue265.y
@@ -1,0 +1,80 @@
+{
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+-- For ancient GHC 7.0.4
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Main where
+
+import Control.Monad (when)
+import Data.Char
+import System.Exit
+}
+
+%name parseStmts
+%tokentype { Token }
+%errorhandlertype explist
+%error { handleError }
+
+%monad { ParseM } { (>>=) } { return }
+
+%token
+  '1' { TOne }
+  '+' { TPlus }
+  ';' { TSemi }
+
+%%
+
+Stmts : {- empty -}    { [] }
+      | Stmt           { [$1] }
+      | Stmts ';' Stmt { $1 ++ [$3] }
+
+Stmt : Exp { ExpStmt $1 }
+
+Exp : '1'                { One }
+    | Exp '+' Exp %shift { Plus $1 $3 }
+
+{
+data Token = TOne | TPlus | TSemi
+  deriving (Eq,Show)
+
+type Stmts = [Stmt]
+data Stmt = ExpStmt Exp
+  deriving (Eq, Show)
+data Exp = One | Plus Exp Exp
+  deriving (Eq, Show)
+
+type ParseM = Either ParseError
+
+data ParseError
+        = ParseError [String]
+    deriving Eq
+instance Show ParseError where
+  show (ParseError exp) = "Parse error. Expected: " ++ show exp
+
+recordParseError :: [String] -> ParseM a
+recordParseError expected = Left (ParseError expected)
+
+handleError :: ([Token], [String]) -> ParseM a
+handleError (ts, expected) = recordParseError expected
+
+lexer :: String -> [Token]
+lexer [] = []
+lexer (c:cs)
+    | isSpace c = lexer cs
+    | c == '1'  = TOne:(lexer cs)
+    | c == '+'  = TPlus:(lexer cs)
+    | c == ';'  = TSemi:(lexer cs)
+    | otherwise = error "lexer error"
+
+main :: IO ()
+main = do
+  test "11;1" $ \res -> res == Left (ParseError ["';'","'+'"])
+  where
+    test inp p = do
+      putStrLn $ "testing " ++ inp
+      let tokens = lexer inp
+      let res = parseStmts tokens
+      when (not (p res)) $ do
+        print res
+        exitWith (ExitFailure 1)
+}

--- a/tests/monaderror-explist.y
+++ b/tests/monaderror-explist.y
@@ -46,9 +46,9 @@ data Token
 	| TokenTest
     deriving (Eq,Show)
 
-handleErrorExpList :: ([Token], [String]) -> ParseM a
-handleErrorExpList ([], _) = throwError $ ParseError Nothing
-handleErrorExpList (ts, explist) = throwError $ ParseError $ Just $ (head ts, explist)
+handleErrorExpList :: [Token] -> [String] -> ParseM a
+handleErrorExpList [] _ = throwError $ ParseError Nothing
+handleErrorExpList ts explist = throwError $ ParseError $ Just $ (head ts, explist)
 
 lexer :: String -> [Token]
 lexer [] = []

--- a/tests/monaderror-explist.y
+++ b/tests/monaderror-explist.y
@@ -14,8 +14,8 @@ import Data.List (isPrefixOf)
 
 %name parseFoo
 %tokentype { Token }
-%errorhandlertype explist
 %error { handleErrorExpList }
+%error.expected
 
 %monad { ParseM } { (>>=) } { return }
 

--- a/tests/monaderror-resume.y
+++ b/tests/monaderror-resume.y
@@ -93,10 +93,10 @@ main :: IO ()
 main = do
   test "1+1;1" $ \(_,mb_ast) -> mb_ast == Just [ExpStmt (One `Plus` One), ExpStmt One]
   test "1++1;1" $ \(errs,_) -> errs == [ParseError ["'1'"]]
-  test "1++1;+" $ \(errs,_) -> errs == [ParseError ["'1'"], ParseError ["'1'"]]
+  test "1++1;1;+" $ \(errs,_) -> errs == [ParseError ["'1'"], ParseError ["'1'"]]
   test "11;1" $ \(errs,_) -> errs == [ParseError ["';'"]]
-  test "11;++" $ \(errs,_) -> errs == [ParseError ["';'"], ParseError ["'1'"]]
-  test "11;1++" $ \(errs,_) -> errs == [ParseError ["';'"], ParseError ["'1'"]]
+  test "11;1;++" $ \(errs,_) -> errs == [ParseError ["';'"], ParseError ["'1'"]]
+  test "11;1;1++" $ \(errs,_) -> errs == [ParseError ["';'"], ParseError ["'1'"]]
   testExp "11" $ \(errs,_) -> errs == [ParseError ["'+'"]]
   where
     test inp p = do

--- a/tests/monaderror-resume.y
+++ b/tests/monaderror-resume.y
@@ -1,0 +1,115 @@
+{
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+-- For ancient GHC 7.0.4
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Main where
+
+import Control.Monad (when)
+import Data.Char
+import System.Exit
+}
+
+%name parseStmts
+%tokentype { Token }
+%errorresumptive          -- the entire point of this test
+%errorhandlertype explist -- as in monaderror-explist.y
+%error { handleError }
+
+%monad { ParseM } { (>>=) } { return }
+
+%token
+  '1' { TOne }
+  '+' { TPlus }
+  ';' { TSemi }
+
+%%
+
+Stmts : {- empty -}           { [] }
+      | Stmt                  { [$1] }
+      | Stmts ';' Stmt        { $1 ++ [$3] }
+      | catch ';' Stmt %shift { [$3] } -- Could insert error AST token here in place of $1
+      | catch                 { [] }   -- Catch-all at the end
+
+Stmt : Exp { ExpStmt $1 }
+
+Exp : '1'                { One }
+    | Exp '+' Exp %shift { Plus $1 $3 }
+
+{
+data Token = TOne | TPlus | TSemi
+  deriving (Eq,Show)
+
+type Stmts = [Stmt]
+data Stmt = ExpStmt Exp
+  deriving (Eq, Show)
+data Exp = One | Plus Exp Exp
+  deriving (Eq, Show)
+
+----------- Validation monad
+data Validate e a = V e (Maybe a)
+  deriving Functor
+instance Monoid e => Applicative (Validate e) where
+  pure a = V mempty (Just a)
+  V e1 f <*> V e2 a = V (e1 <> e2) (f <*> a)
+instance Monoid e => Monad (Validate e) where
+  V e Nothing   >>= _ = V e Nothing -- fatal
+  V e1 (Just a) >>= k | V e2 b <- k a = V (e1 <> e2) b -- non-fatal
+
+abort :: Monoid e => Validate e a -- this would be mzero from MonadPlus
+abort = V mempty Nothing
+
+recordError :: e -> Validate e () -- this would be tell from MonadWriter
+recordError e = V e (Just ())
+
+runValidate (V e mb_a) = (e, mb_a)
+-----------
+
+type ParseM = Validate [ParseError]
+
+data ParseError
+        = ParseError [String]
+    deriving Eq
+instance Show ParseError where
+  show (ParseError exp) = "Parse error. Expected: " ++ show exp
+
+recordParseError :: [String] -> ParseM ()
+recordParseError expected = recordError [ParseError expected]
+
+handleError :: [Token] -> [String] -> ([Token] -> ParseM (Maybe a)) -> ParseM a
+handleError ts expected resume = do
+  recordParseError expected
+  mb_ast <- resume ts
+  case mb_ast of
+    Just ast -> return ast
+    Nothing  -> abort -- abort after parsing with no AST when resumption is impossible
+
+lexer :: String -> [Token]
+lexer [] = []
+lexer (c:cs)
+    | isSpace c = lexer cs
+    | c == '1'  = TOne:(lexer cs)
+    | c == '+'  = TPlus:(lexer cs)
+    | c == ';'  = TSemi:(lexer cs)
+    | otherwise = error "lexer error"
+
+main :: IO ()
+main = do
+  test "1+1;1" $ \(_,mb_ast) -> mb_ast == Just [ExpStmt (One `Plus` One), ExpStmt One]
+  test "1++1;1" $ \(errs,_) -> errs == [ParseError ["'1'"]]
+  test "1++1;+" $ \(errs,_) -> errs == [ParseError ["'1'"], ParseError ["'1'"]]
+  test "11;1" $ \(errs,_) -> errs == [ParseError []]
+    -- urgh, `Exp -> '1' .` is purely a reduction action.
+    -- We must walk the stack to get better messages
+  test "11;++" $ \(errs,_) -> errs == [ParseError [], ParseError ["'1'"]]
+    -- urgh, `Exp -> '1' .` is purely a reduction action.
+    -- We must walk the stack to get better messages
+  where
+    test inp p = do
+      putStrLn $ "testing " ++ inp
+      let tokens = lexer inp
+      let res = runValidate $ parseStmts tokens
+      when (not (p res)) $ do
+        print res
+        exitWith (ExitFailure 1)
+}


### PR DESCRIPTION
Superseded by #318.

A drafty PoC serving as motivation for a GSoC proposal; I don't want to see this merged or reviewed for now. 

---

Consider this excerpt from an example (`errormonad-resume.y`):

```hs
%name parseStmts Stmts
%tokentype { Token }
%error { \_ -> abort } { reportError } -- the entire point of this test

%monad { ParseM } { (>>=) } { return }

%token
  '1' { TOne }
  '+' { TPlus }
  ';' { TSemi }

%%

Stmts : {- empty -}           { [] }
      | Stmt                  { [$1] }
      | Stmts ';' Stmt        { $1 ++ [$3] }
      | catch ';' Stmt %shift { [$3] } -- Could insert error AST token here in place of $1

Stmt : Exp { ExpStmt $1 }

Exp : '1'                { One }
    | Exp '+' Exp %shift { Plus $1 $3 }

{
recordParseError :: [String] -> ParseM ()
recordParseError expected = recordError [ParseError expected]

reportError :: [Token] -> [String] -> ([Token] -> ParseM a) -> ParseM a
reportError ts expected resume = do
  recordParseError expected
  resume ts
```

The point of this example is that *reporting* a parse error (i.e. adding a diagnostic) is independent from *aborting* a parse (i.e., a fatal error that can't produce a syntax tree). Hence the new `%error` form takes two code blocks: One for the abort handler, the other for the report handler.

Additionally, the report handler gets a `resume` continuation that it may call to resume parsing; otherwise it would simply have to abort (TODO: In the current encoding it should perhaps simply be `ParseM ()` and we call the resumption unconditionally).

Where does the parser resume parsing? That is mostly up to the user to specify, through use of the special `catch` terminal. In the example above, `catch` occurs before a `;` is shifted, so that upon an error during parsing a `Stmt`, the parser will "unwind" the stack until it finds a situation in which `catch` can be shifted. After having done that, it will discard input until it finds the next `;` so as to resume parsing.

The result is that for inputs such as `1++1;1;+`, two errors (and a partial syntax tree) can be reported: One at the second `+` and the other at the third.

I've already tried to apply this patch to GHC; it seems to work: See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11990 for a worked example. 