### PR TITLE
Support GHC as the only compiler to build happy generated parsers

### DIFF
--- a/packages/backend-glr/data/GLR_Lib.hs
+++ b/packages/backend-glr/data/GLR_Lib.hs
@@ -37,8 +37,8 @@
            )
   where
 
-#if defined(HAPPY_GHC) && !defined(__GLASGOW_HASKELL__)
-#  error `HAPPY_GHC` is defined but this code isn't being built with GHC.
+#if !defined(__GLASGOW_HASKELL__)
+#  error This code isn't being built with GHC.
 #endif
 
 import Data.Char
@@ -48,10 +48,9 @@ import Control.Applicative (Applicative(..))
 import Control.Monad (foldM, ap)
 import Data.Maybe (fromJust)
 import Data.List (insertBy, nub, maximumBy, partition, find, groupBy, delete)
-#if defined(HAPPY_GHC)
+
 import GHC.Prim
 import GHC.Exts
-#endif
 
 #if defined(HAPPY_DEBUG)
 import System.IO
@@ -65,7 +64,6 @@ fakeimport DATA
 
 {- borrowed from GenericTemplate.hs -}
 
-#ifdef HAPPY_GHC
 #define ILIT(n) n#
 #define BANG !
 #define IBOX(n) (I# (n))
@@ -87,21 +85,6 @@ fakeimport DATA
 #define NEGATE(n) (negateInt# (n))
 #define IF_GHC(x) (x)
 
-#else
-
-#define ILIT(n) (n)
-#define BANG
-#define IBOX(n) (n)
-#define FAST_INT Int
-#define ULT(n,m) (n < m)
-#define GTE(n,m) (n >= m)
-#define UEQ(n,m) (n == m)
-#define PLUS(n,m) (n + m)
-#define MINUS(n,m) (n - m)
-#define TIMES(n,m) (n * m)
-#define NEGATE(n) (negate (n))
-#define IF_GHC(x)
-#endif
 
 #if defined(HAPPY_DEBUG)
 #define DEBUG_TRACE(s)    (happyTrace (s) $ return ())

--- a/packages/backend-lalr/data/HappyTemplate.hs
+++ b/packages/backend-lalr/data/HappyTemplate.hs
@@ -19,8 +19,8 @@
 #define TIMES(n,m) (n Happy_GHC_Exts.*# m)
 #define NEGATE(n) (Happy_GHC_Exts.negateInt# (n))
 
-type FastInt = Happy_GHC_Exts.Int#
-data Happy_IntList = HappyCons FastInt Happy_IntList
+type Happy_Int = Happy_GHC_Exts.Int#
+data Happy_IntList = HappyCons Happy_Int Happy_IntList
 
 #define ERROR_TOK 0#
 
@@ -74,20 +74,20 @@ happyDoAction i tk st
                                                   happyFail (happyExpListPerState ((Happy_GHC_Exts.I# st) :: Prelude.Int)) i tk st
                 -1#                       -> DEBUG_TRACE("accept.\n")
                                                   happyAccept i tk st
-                n | LT(n,(0# :: FastInt)) -> DEBUG_TRACE("reduce (rule " ++ show rule
+                n | LT(n,(0# :: Happy_Int)) -> DEBUG_TRACE("reduce (rule " ++ show rule
                                                                ++ ")")
                                                    (happyReduceArr Happy_Data_Array.! rule) i tk st
                   where
-                    rule = Happy_GHC_Exts.I# (NEGATE(PLUS(n,(1# :: FastInt))))
+                    rule = Happy_GHC_Exts.I# (NEGATE(PLUS(n,(1# :: Happy_Int))))
 
                 n                         -> DEBUG_TRACE("shift, enter state "
                                                          ++ show (Happy_GHC_Exts.I# new_state)
                                                          ++ "\n")
                                                happyShift new_state i tk st
-                  where new_state = MINUS(n,(1# :: FastInt))
+                  where new_state = MINUS(n,(1# :: Happy_Int))
    where off    = happyAdjustOffset (indexShortOffAddr happyActOffsets st)
          off_i  = PLUS(off, i)
-         check  = if GTE(off_i,(0# :: FastInt))
+         check  = if GTE(off_i,(0# :: Happy_Int))
                   then EQ(indexShortOffAddr happyCheck off_i, i)
                   else Prelude.False
          action
@@ -155,7 +155,7 @@ happySpecReduce_3 nt fn j tk _
 happyReduce k i fn ERROR_TOK tk st sts stk
      = happyFail [] ERROR_TOK tk st sts stk
 happyReduce k nt fn j tk st sts stk
-     = case happyDrop MINUS(k,(1# :: FastInt)) sts of
+     = case happyDrop MINUS(k,(1# :: Happy_Int)) sts of
          sts1@(HappyCons st1 _) ->
                 let r = fn stk in -- it doesn't hurt to always seq here...
                 happyDoSeq r (happyGoto nt j tk st1 sts1 r)
@@ -183,10 +183,10 @@ happyMonad2Reduce k nt fn j tk st sts stk =
                        (\r -> happyNewToken new_state sts1 (r `HappyStk` drop_stk))
 
 happyDrop 0# l               = l
-happyDrop n  (HappyCons _ t) = happyDrop MINUS(n,(1# :: FastInt)) t
+happyDrop n  (HappyCons _ t) = happyDrop MINUS(n,(1# :: Happy_Int)) t
 
 happyDropStk 0# l                 = l
-happyDropStk n  (x `HappyStk` xs) = happyDropStk MINUS(n,(1#::FastInt)) xs
+happyDropStk n  (x `HappyStk` xs) = happyDropStk MINUS(n,(1#::Happy_Int)) xs
 
 -----------------------------------------------------------------------------
 -- Moving to a new state after a reduction
@@ -232,7 +232,7 @@ notHappyAtAll = Prelude.error "Internal Happy error\n"
 -----------------------------------------------------------------------------
 -- Hack to get the typechecker to accept our action functions
 
-happyTcHack :: FastInt -> a -> a
+happyTcHack :: Happy_Int -> a -> a
 happyTcHack x y = y
 {-# INLINE happyTcHack #-}
 

--- a/packages/backend-lalr/src/Happy/Backend/LALR.hs
+++ b/packages/backend-lalr/src/Happy/Backend/LALR.hs
@@ -18,11 +18,9 @@ magicFilter magicName = case magicName of
         filter_output [] = []
       in filter_output
 
-importsToInject :: Bool -> Bool -> String
-importsToInject ghc debug = concat ["\n", import_array, import_bits, glaexts_import, debug_imports, applicative_imports]
+importsToInject :: Bool -> String
+importsToInject debug = concat ["\n", import_array, import_bits, import_glaexts, debug_imports, applicative_imports]
     where
-      glaexts_import | ghc       = import_glaexts
-                     | otherwise = ""
       debug_imports  | debug     = import_debug
                      | otherwise = ""
       applicative_imports        = import_applicative
@@ -36,16 +34,13 @@ importsToInject ghc debug = concat ["\n", import_array, import_bits, glaexts_imp
       import_applicative = "import Control.Applicative(Applicative(..))\n" ++
                            "import Control.Monad (ap)\n"
 
-langExtsToInject :: Bool -> [String]
-langExtsToInject ghc
-  | ghc = ["MagicHash", "BangPatterns", "TypeSynonymInstances", "FlexibleInstances"]
-  | otherwise = []
+langExtsToInject :: [String]
+langExtsToInject = ["MagicHash", "BangPatterns", "TypeSynonymInstances", "FlexibleInstances"]
 
-defines :: Bool -> Bool -> Bool -> String
-defines debug ghc coerce = unlines [ "#define " ++ d ++ " 1" | d <- vars_to_define ]
+defines :: Bool -> Bool -> String
+defines debug coerce = unlines [ "#define " ++ d ++ " 1" | d <- vars_to_define ]
   where
   vars_to_define = concat
     [ [ "HAPPY_DEBUG"  | debug ]
-    , [ "HAPPY_GHC"    | ghc ]
     , [ "HAPPY_COERCE" | coerce ]
     ]

--- a/src/Main.lhs
+++ b/src/Main.lhs
@@ -173,7 +173,6 @@ of code we should generate, and where it should go:
 >       outfilename <- getOutputFileName fl_name cli
 >       opt_coerce  <- getCoerce cli
 >       opt_strict  <- getStrict cli
->       opt_ghc     <- getGhc cli
 >       opt_debug   <- getDebug cli
 
 Add any special options or imports required by the parsing machinery.
@@ -181,7 +180,7 @@ Add any special options or imports required by the parsing machinery.
 >       let
 >           header = Just $
 >             (case hd of Just s -> s; Nothing -> "")
->             ++ importsToInject opt_ghc opt_debug
+>             ++ importsToInject opt_debug
 
 >       if OptGLR `elem` cli
 
@@ -198,14 +197,12 @@ Branch off to GLR parser production
 >             filtering
 >               | OptGLR_Filter `elem` cli = UseFiltering
 >               | otherwise                = NoFiltering
->             ghc_exts
->               | OptGhcTarget `elem` cli  = UseGhcExts
->                                              (importsToInject opt_ghc opt_debug)
+>             ghc_exts                     = UseGhcExts
+>                                              (importsToInject opt_debug)
 
 Unlike below, don't always pass CPP, because only one of the files needs it.
 
->                                              (langExtsToInject opt_ghc)
->               | otherwise                = NoGhcExts
+>                                              (langExtsToInject)
 >           template' <- getTemplate glrBackendDataDir cli
 >           let basename  = takeWhile (/='.') outfilename
 >           let tbls  = (action,goto)
@@ -259,14 +256,13 @@ and generate the code.
 
 CPP is needed in all cases with unified template
 
->                           ("CPP" : langExtsToInject opt_ghc)
+>                           ("CPP" : langExtsToInject)
 >                           header
 >                           tl
 >                           opt_coerce
->                           opt_ghc
 >                           opt_strict
 
->               defines' = defines opt_debug opt_ghc opt_coerce
+>               defines' = defines opt_debug opt_coerce
 
 >           (if outfilename == "-" then putStr else writeFile outfilename)
 >                   (magicFilter magic_name (outfile ++ defines' ++ templ))
@@ -414,16 +410,7 @@ Extract various command-line options.
 >               f:fs       -> return (Just (map toLower (last (f:fs))))
 
 > getCoerce :: [CLIFlags] -> IO Bool
-> getCoerce cli
->       = if OptUseCoercions `elem` cli
->            then if OptGhcTarget `elem` cli
->                       then return True
->                       else dieHappy ("-c/--coerce may only be used " ++
->                                      "in conjunction with -g/--ghc\n")
->            else return False
-
-> getGhc :: [CLIFlags] -> IO Bool
-> getGhc cli = return (OptGhcTarget `elem` cli)
+> getCoerce cli = return (OptUseCoercions `elem` cli)
 
 > getStrict :: [CLIFlags] -> IO Bool
 > getStrict cli = return (OptStrict `elem` cli)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,9 +25,9 @@ endif
 # [2021-07-14, PR #196](https://github.com/haskell/happy/pull/196)
 #
 HC ?= ghc
-HC_OPTS=-Wall -Werror
+HC_OPTS=-package array -Wall -Werror
 
-.PRECIOUS: %.n.hs %.o %.exe %.bin
+.PRECIOUS: %.n.hs %.c.hs %.o %.exe %.bin
 
 ifeq "$(TARGETPLATFORM)" "i386-unknown-mingw32"
 HS_PROG_EXT = .exe
@@ -50,15 +50,21 @@ ERROR_TESTS = error001.y
 #TEST_HAPPY_OPTS = --strict --template=..
 TEST_HAPPY_OPTS = --strict
 
-%.n.hs : %.ly
-	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
-
 %.n.hs : %.y
 	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
 
+%.n.hs : %.ly
+	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
+
+%.c.hs : %.y
+	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
+
+%.c.hs : %.ly
+	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
+
 CLEAN_FILES += *.n.hs *.c.hs *.info *.hi *.bin *.exe *.o *.run.stdout *.run.stderr
 
-ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs /g')
+ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs \1.c.hs/g')
 
 ALL_TESTS = $(patsubst %.hs, %.run, $(ALL_TEST_HS))
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,18 +53,12 @@ TEST_HAPPY_OPTS = --strict
 %.n.hs : %.ly
 	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
 
-%.c.hs : %.ly
-	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
-
 %.n.hs : %.y
 	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
 
-%.c.hs : %.y
-	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
-
 CLEAN_FILES += *.n.hs *.c.hs *.info *.hi *.bin *.exe *.o *.run.stdout *.run.stderr
 
-ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs \1.c.hs/g')
+ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs /g')
 
 ALL_TESTS = $(patsubst %.hs, %.run, $(ALL_TEST_HS))
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,7 +27,7 @@ endif
 HC ?= ghc
 HC_OPTS=-Wall -Werror
 
-.PRECIOUS: %.n.hs %.g.hs %.o %.exe %.bin
+.PRECIOUS: %.n.hs %.o %.exe %.bin
 
 ifeq "$(TARGETPLATFORM)" "i386-unknown-mingw32"
 HS_PROG_EXT = .exe
@@ -53,24 +53,18 @@ TEST_HAPPY_OPTS = --strict
 %.n.hs : %.ly
 	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
 
-%.g.hs : %.ly
-	$(HAPPY) $(TEST_HAPPY_OPTS) -g $< -o $@
-
-%.gc.hs : %.ly
-	$(HAPPY) $(TEST_HAPPY_OPTS) -gc $< -o $@
+%.c.hs : %.ly
+	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
 
 %.n.hs : %.y
 	$(HAPPY) $(TEST_HAPPY_OPTS) $< -o $@
 
-%.g.hs : %.y
-	$(HAPPY) $(TEST_HAPPY_OPTS) -g $< -o $@
+%.c.hs : %.y
+	$(HAPPY) $(TEST_HAPPY_OPTS) -c $< -o $@
 
-%.gc.hs : %.y
-	$(HAPPY) $(TEST_HAPPY_OPTS) -gc $< -o $@
+CLEAN_FILES += *.n.hs *.c.hs *.info *.hi *.bin *.exe *.o *.run.stdout *.run.stderr
 
-CLEAN_FILES += *.n.hs *.g.hs *.gc.hs *.info *.hi *.bin *.exe *.o *.run.stdout *.run.stderr
-
-ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs \1.g.hs \1.gc.hs/g')
+ALL_TEST_HS = $(shell echo $(TESTS) | sed -e 's/\([^\. ]*\)\.\(l\)\{0,1\}y/\1.n.hs \1.c.hs/g')
 
 ALL_TESTS = $(patsubst %.hs, %.run, $(ALL_TEST_HS))
 
@@ -101,11 +95,7 @@ check-todo::
 	$(HC) Test.hs -o happy_test
 	./happy_test
 	-rm -f ./happy_test
-	$(HAPPY) $(TEST_HAPPY_OPTS) -gd Test.ly
-	$(HC) Test.hs -o happy_test
-	./happy_test
-	-rm -f ./happy_test
-	$(HAPPY) $(TEST_HAPPY_OPTS) -gcd Test.ly
+	$(HAPPY) $(TEST_HAPPY_OPTS) -cd Test.ly
 	$(HC) Test.hs -o happy_test
 	./happy_test
 	-rm -f ./happy_test


### PR DESCRIPTION
This PR removes all the code related `-g/--ghc` args, making it on by default, removing all conditional code based on it, so that the generated parsers can only build with GHC compiler.

@int-index @Ericson2314 @sgraf812 This PR is has another commit, from #276, ignore it for now, I based the second commit on it just to make merging both easier, rather than doing rebase/merge later.

