### PR TITLE
Suppress warnings for incomplete uni-patterns and partial use of head 

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -153,7 +153,7 @@ executable happy
 
   default-language: Haskell98
   default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns
-  ghc-options: -Wall
+  ghc-options: -Wall -Wno-incomplete-uni-patterns
   other-modules:
         Paths_happy
 


### PR DESCRIPTION
All the incomplete matches are in fact safe. The warnings only add noise.

https://github.com/haskell/happy/pull/247 is related, but a non-solution.