### PR TITLE
Attribute grammar cleanup

### DIFF
--- a/app/Main.lhs
+++ b/app/Main.lhs
@@ -82,7 +82,7 @@ Parse, using bootstrapping parser.
 
 Mangle the syntax into something useful.
 
->       (g, common_options) <- case {-# SCC "Mangler" #-} mangler fl_name abssyn of
+>       (g, mAg, common_options) <- case {-# SCC "Mangler" #-} mangler fl_name abssyn of
 >               Left  s  -> die (unlines s ++ "\n")
 >               Right gd -> return gd
 
@@ -254,6 +254,7 @@ and generate the code.
 >           let
 >               outfile = produceParser
 >                           g
+>                           mAg
 >                           common_options
 >                           action
 >                           goto

--- a/lib/frontend/src/Happy/Frontend/AbsSyn.lhs
+++ b/lib/frontend/src/Happy/Frontend/AbsSyn.lhs
@@ -12,11 +12,11 @@ Here is the abstract syntax of the language we parse.
 >       getTokenType, getTokenSpec, getParserNames, getLexer,
 >       getImportedIdentity, getMonad, getError,
 >       getPrios, getPrioNames, getExpect, getErrorHandlerType,
->       getAttributes, getAttributetype,
+>       getAttributes, getAttributetype, getAttributeGrammarExtras,
 >       Rule(..), Prod(..), Term(..), Prec(..)
 >  ) where
 
-> import Happy.Grammar (ErrorHandlerType(..))
+> import Happy.Grammar (ErrorHandlerType(..), AttributeGrammarExtras(..))
 
 > data BookendedAbsSyn
 >     = BookendedAbsSyn
@@ -161,3 +161,12 @@ generate some error messages.
 >                  [t] -> Just t
 >                  []  -> Nothing
 >                  _   -> error "multiple attributetype directives"
+
+> getAttributeGrammarExtras :: [Directive t] -> Maybe AttributeGrammarExtras
+> getAttributeGrammarExtras ds = case (getAttributes ds, getAttributetype ds) of
+>   ([], Nothing) -> Nothing
+>   (as, Just at) -> Just $ AttributeGrammarExtras {
+>           attributes = as,
+>           attributetype = at
+>       }
+>   (_ : _, Nothing) -> error "attributes found without attribute type directive"

--- a/lib/frontend/src/Happy/Frontend/AttrGrammar/Mangler.lhs
+++ b/lib/frontend/src/Happy/Frontend/AttrGrammar/Mangler.lhs
@@ -21,8 +21,8 @@ manipulation and let binding goop
 
 > import Control.Monad
 
-> rewriteAttributeGrammar :: [Name] -> [Name] -> String -> [(String,String)] -> M (String,[Int])
-> rewriteAttributeGrammar lhs nonterm_names code attrs =
+> rewriteAttributeGrammar :: [Name] -> [Name] -> String -> AttributeGrammarExtras -> M (String,[Int])
+> rewriteAttributeGrammar lhs nonterm_names code ag =
 
    first we need to parse the body of the code block
 
@@ -38,7 +38,7 @@ manipulation and let binding goop
 >                  , subRules :: [AgSubAssign]
 >                  , conditions :: [AgConditional]
 >                  ) = partitionRules [] [] [] rules
->                attrNames = map fst attrs
+>                attrNames = map fst $ attributes ag
 >                defaultAttr = head attrNames
 
    now check that $i references are in range

--- a/lib/grammar/src/Happy/Grammar.lhs
+++ b/lib/grammar/src/Happy/Grammar.lhs
@@ -9,6 +9,7 @@ The Grammar data type.
 >       Name,
 >
 >       Production(..), Grammar(..),
+>       AttributeGrammarExtras(..),
 >       Priority(..),
 >       Assoc(..),
 >       Pragmas(..), ErrorHandlerType(..),
@@ -41,7 +42,11 @@ The Grammar data type.
 >               first_nonterm     :: Name,
 >               first_term        :: Name,
 >               eof_term          :: Name,
->               priorities        :: [(Name,Priority)],
+>               priorities        :: [(Name,Priority)]
+>       }
+
+> data AttributeGrammarExtras
+>       = AttributeGrammarExtras {
 >               attributes        :: [(String,String)],
 >               attributetype     :: String
 >       }


### PR DESCRIPTION
I want to better separate the attribute grammar stuff

- Much code doesn't care at all (rightly or wrongly), so we can use the types to track which does does.

- Only one backend supports it, it should be ill-typed to try to use it with the other backend. (This is not yet achieved, but step in that directly.

- Generally trying to slim down `Grammar` to just the essentials, the grammar itself.