### PR TITLE
Release preparations for 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cabal.sandbox.config
 .*.swp
 .*.swo
 /.vscode/
+tests/*.hs

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,21 +2,35 @@
 
 ## 2.0
 
-The main focus of this release was modularizing Happy.
+There are two main breaking changes in this release:
 
-* Generated parsers now activate the language extension `-XNoStrictData` without
-  which every use of a happy parser would lead to an immediate crash (#273).
-  This causes us to drop support for GHC < 8.0.
+1. Removal non-array, non-GHC modes, so flags `-ag` are the default now and
+   become no-ops.
+2. Generated parsers now activate the language extension `-XNoStrictData` without
+   which every use of a happy parser would lead to an immediate crash (#273).
+   This causes us to drop support for GHC < 8.0.
 
-* Break up into libraries:
+Furthermore, the project structure was modularized and a library `happy-lib`
+containing the implmentation of the `happy` executable was extracted.
 
-  - `happy-backend-glr`
-  - `happy-backend-lalr`
-  - `happy-frontend`
-  - `happy-grammar`
-  - `happy-tabular`
+Quite similar to the situation with GHC vs. the GHC API, we expect that `happy`
+will continue to be a stable CLI tool with solid (if occasionally out of date)
+documentation, while the design, documentation and implementation of `happy-lib`
+is still in flux and use is only recommended to expert users.
 
-* Revert the new bootstrapping system of 1.21.0 to mitigate build issues.
+Other, more minor changes:
+
+* Revert the new bootstrapping system of 1.21.0 to mitigate build issues (#255, #274).
+
+* Encode action table offsets in 32 bit instead of 16 bit (#93, #199, #266).
+  This increases the size of generated parsers a bit (about 250KB for GHC's
+  parser), but also manages to generate parsers for grammars that were
+  previously running into the size limit (#199).
+
+* The documentation has been converted to ReStructuredText,
+  hosted at https://haskell-happy.readthedocs.io/en/latest/ (#226)
+
+* A few internal refactorings to the structure of generated code.
 
 ## 1.21.0
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -16,9 +16,11 @@ feel free to submit them!
 Repo Layout
 -----------
 
-- ``src``: The source code for the Happy executable itself
+- ``app``: The source code for the Happy executable itself
 
-- ``packages/*``: The various packages that make up Happy behind the scenes, and are available for reuse for other purposes.
+- ``lib/*``: The various internal libraries that make up the ``happy-lib``
+  package. This library is used to implement the ``happy`` executable behind the
+  scenes, and is available for reuse for other purposes.
 
 - ``doc``: The documentation
 
@@ -34,20 +36,20 @@ Happy is mostly a normal Cabal-packaged Haskell executable::
 
     $ cabal build
 
-The only wrinkle is that developing Happy's own parser (i.e. the frontend
+The only wrinkle is that changing Happy's own parser (i.e. the frontend
 component that parses ``.y`` files) requires an existing Happy executable on
-the PATH.
+the PATH to run ``lib/frontend/boostrap.sh``.
 
 Do *not* modify these files by hand::
 
-    packages/frontend/src/Happy/Frontend/Parser.hs
-    packages/frontend/src/Happy/Frontend/AttrGrammar/Parser.hs
+    lib/frontend/src/Happy/Frontend/Parser.hs
+    lib/frontend/src/Happy/Frontend/AttrGrammar/Parser.hs
 
 Instead, edit these files::
 
-    packages/frontend/boot-src/Parser.ly
-    packages/frontend/boot-src/AttrGrammarParser.ly
+    lib/frontend/boot-src/Parser.ly
+    lib/frontend/boot-src/AttrGrammarParser.ly
 
 and regenerate the ``.hs``-files with::
 
-    $ packages/frontend/bootstrap.sh
+    $ lib/frontend/bootstrap.sh

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -153,6 +153,8 @@ Current Maintainers
 
 - John Ericson (@Ericson2314)
 
+- Sebastian Graf (@sgraf812)
+
 - Simon Marlow (@simonmar)
 
 Other contributors


### PR DESCRIPTION
I mostly completed the ChangeLog from looking at [this list](https://github.com/haskell/happy/commits/master?since=2021-10-17&until=2024-09-16).

If someone would give me the necessary hackage credentials (user sgraf812), I would be happy to do the hackage release.
I would just use `nix run nixpkgs#hkgr -- publish` to do so. Or is there some documented procedure one should follow for releases? At any rate, we should document the procedure. Perhaps in `CONTRIBUTING.rst`?