### PR TITLE
Remove redundant paramater

### DIFF
--- a/app/Main.lhs
+++ b/app/Main.lhs
@@ -123,7 +123,6 @@ Print out the info file.
 >                       g
 >                       action
 >                       goto
->                       (token_specs g)
 >                       conflictArray
 >                       fl_name
 >                       unused_rules

--- a/lib/tabular/src/Happy/Tabular/Info.lhs
+++ b/lib/tabular/src/Happy/Tabular/Info.lhs
@@ -22,7 +22,6 @@ Produce a file of parser information, useful for debugging the parser.
 >       -> Grammar e
 >       -> ActionTable
 >       -> GotoTable
->       -> [(Int,String)]
 >       -> Array Int (Int,Int)
 >       -> String
 >       -> [Int]                        -- unused rules
@@ -36,8 +35,9 @@ Produce a file of parser information, useful for debugging the parser.
 >                , lookupProdsOfName = lookupProdNos
 >                , non_terminals = nonterms
 >                , token_names = env
+>                , token_specs = tokens
 >                })
->        action goto tokens conflictArray filename unused_rules unused_terminals version
+>        action goto conflictArray filename unused_rules unused_terminals version
 >       = (showHeader
 >       . showConflicts
 >       . showUnused


### PR DESCRIPTION
We're already taking the entire grammar, so we don't need to separately take a field of the grammar.