### PR TITLE
Improve the abstract syntax for tokens

### DIFF
--- a/lib/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
+++ b/lib/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
@@ -9,6 +9,7 @@ The code generator.
 > import Paths_happy_lib  ( version )
 > import Data.Version              ( showVersion )
 > import Happy.Grammar
+> import Happy.Grammar.ExpressionWithHole ( substExpressionWithHole )
 > import Happy.Tabular.LALR
 
 > import Data.Maybe                ( isNothing, fromMaybe )
@@ -417,19 +418,17 @@ The token conversion function.
 Use a variable rather than '_' to replace '$$', so we can use it on
 the left hand side of '@'.
 
->         removeDollarDollar xs = case mapDollarDollar xs of
->                                  Nothing -> xs
->                                  Just fn -> fn "happy_dollar_dollar"
+>         removeDollarDollar tok = case tok of
+>              TokenFixed t -> t
+>              TokenWithValue e -> substExpressionWithHole e "happy_dollar_dollar"
 
 >    mkHappyTerminalVar :: Int -> Int -> String -> String
 >    mkHappyTerminalVar i t =
->     case tok_str_fn of
+>     case lookup t token_rep of
 >       Nothing -> pat
->       Just fn -> brack (fn (pat []))
+>       Just (TokenFixed _) -> pat
+>       Just (TokenWithValue e) -> brack $ substExpressionWithHole e $ pat []
 >     where
->         tok_str_fn = case lookup t token_rep of
->                     Nothing -> Nothing
->                     Just str' -> mapDollarDollar str'
 >         pat = mkHappyVar i
 
 >    tokIndex i = i - n_nonterminals - n_starts - 2

--- a/lib/frontend/boot-src/Parser.ly
+++ b/lib/frontend/boot-src/Parser.ly
@@ -132,12 +132,12 @@ The parser.
 >       : id                            { Just $1 }
 >       | {- nothing -}                 { Nothing }
 
-> tokenSpecs :: { [(String,String)] }
+> tokenSpecs :: { [(String, TokenSpec)] }
 >       : tokenSpec tokenSpecs          { $1:$2 }
 >       | tokenSpec                     { [$1] }
 
-> tokenSpec :: { (String,String) }
->       : id code                       { ($1,$2) }
+> tokenSpec :: { (String, TokenSpec) }
+>       : id code                       { ($1, parseTokenSpec $2) }
 
 > ids   :: { [String] }
 >       : id ids                        { $1 : $2 }

--- a/lib/frontend/src/Happy/Frontend/Parser.hs
+++ b/lib/frontend/src/Happy/Frontend/Parser.hs
@@ -135,15 +135,15 @@ happyIn19 x = Happy_GHC_Exts.unsafeCoerce# (HappyWrap19 x)
 happyOut19 :: (HappyAbsSyn ) -> HappyWrap19
 happyOut19 x = Happy_GHC_Exts.unsafeCoerce# x
 {-# INLINE happyOut19 #-}
-newtype HappyWrap20 = HappyWrap20 ([(String,String)])
-happyIn20 :: ([(String,String)]) -> (HappyAbsSyn )
+newtype HappyWrap20 = HappyWrap20 ([(String, TokenSpec)])
+happyIn20 :: ([(String, TokenSpec)]) -> (HappyAbsSyn )
 happyIn20 x = Happy_GHC_Exts.unsafeCoerce# (HappyWrap20 x)
 {-# INLINE happyIn20 #-}
 happyOut20 :: (HappyAbsSyn ) -> HappyWrap20
 happyOut20 x = Happy_GHC_Exts.unsafeCoerce# x
 {-# INLINE happyOut20 #-}
-newtype HappyWrap21 = HappyWrap21 ((String,String))
-happyIn21 :: ((String,String)) -> (HappyAbsSyn )
+newtype HappyWrap21 = HappyWrap21 ((String, TokenSpec))
+happyIn21 :: ((String, TokenSpec)) -> (HappyAbsSyn )
 happyIn21 x = Happy_GHC_Exts.unsafeCoerce# (HappyWrap21 x)
 {-# INLINE happyIn21 #-}
 happyOut21 :: (HappyAbsSyn ) -> HappyWrap21
@@ -768,7 +768,7 @@ happyReduction_51 happy_x_2
 	 =  case happyOutTok happy_x_1 of { (TokenInfo happy_var_1 TokId) -> 
 	case happyOutTok happy_x_2 of { (TokenInfo happy_var_2 TokCodeQuote) -> 
 	happyIn21
-		 ((happy_var_1,happy_var_2)
+		 ((happy_var_1, parseTokenSpec happy_var_2)
 	)}}
 
 happyReduce_52 :: () => Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> P (HappyAbsSyn )

--- a/lib/grammar/src/Happy/Grammar.lhs
+++ b/lib/grammar/src/Happy/Grammar.lhs
@@ -150,7 +150,11 @@ For array-based parsers, see the note in Tabular/LALR.lhs.
 Replace $$ with an arbitrary string, being careful to avoid ".." and '.'.
 
 > mapDollarDollar :: String -> Maybe (String -> String)
-> mapDollarDollar code0 = go code0 ""
+> mapDollarDollar = fmap (\(l, r) repr -> l ++ repr ++ r) . mapDollarDollar'
+>
+
+> mapDollarDollar' :: String -> Maybe (String, String)
+> mapDollarDollar' code0 = go code0 ""
 >   where go code acc =
 >           case code of
 >               [] -> Nothing
@@ -163,5 +167,5 @@ Replace $$ with an arbitrary string, being careful to avoid ".." and '.'.
 >                                []       -> go r ('\'':acc)
 >                                (c,r'):_ -> go r' (reverse (show c) ++ acc)
 >               '\\':'$':r -> go r ('$':acc)
->               '$':'$':r  -> Just (\repl -> reverse acc ++ repl ++ r)
+>               '$':'$':r  -> Just (reverse acc, r)
 >               c:r  -> go r (c:acc)

--- a/lib/grammar/src/Happy/Grammar/ExpressionWithHole.hs
+++ b/lib/grammar/src/Happy/Grammar/ExpressionWithHole.hs
@@ -1,0 +1,13 @@
+module Happy.Grammar.ExpressionWithHole where
+
+-- | The overall expression is
+-- 'tokLeft ++ substitutedForHole ++ tokRight'.
+data ExpressionWithHole
+      = ExpressionWithHole {
+              exprLeft :: String,
+              exprRight :: String
+      }
+      deriving (Eq, Show)
+
+substExpressionWithHole :: ExpressionWithHole -> String -> String
+substExpressionWithHole (ExpressionWithHole l r) = \repr -> l ++ repr ++ r

--- a/lib/happy-lib.cabal
+++ b/lib/happy-lib.cabal
@@ -75,7 +75,9 @@ common common-stanza
 library grammar
   import: common-stanza
   hs-source-dirs:      grammar/src
-  exposed-modules:     Happy.Grammar
+  exposed-modules:
+       Happy.Grammar
+       Happy.Grammar.ExpressionWithHole
   build-depends:       base < 5, array
 
 library frontend
@@ -129,6 +131,7 @@ library backend-glr
 library
   import: common-stanza
   reexported-modules:  Happy.Grammar,
+                       Happy.Grammar.ExpressionWithHole,
                        Happy.Frontend,
                        Happy.Frontend.AbsSyn,
                        Happy.Frontend.Mangler,

--- a/lib/tabular/src/Happy/Tabular/Info.lhs
+++ b/lib/tabular/src/Happy/Tabular/Info.lhs
@@ -9,6 +9,7 @@ Generating info files.
 > import Data.Set ( Set )
 > import qualified Data.Set as Set hiding ( Set )
 > import Happy.Grammar
+> import Happy.Grammar.ExpressionWithHole ( substExpressionWithHole )
 > import Happy.Tabular.LALR   ( Lr0Item(..), LRAction(..), Goto(..), GotoTable, ActionTable )
 
 > import Data.Array
@@ -182,7 +183,10 @@ Produce a file of parser information, useful for debugging the parser.
 >   showTerminal (t,s)
 >       = str "\t"
 >       . showJName 15 t
->       . str "{ " . str s . str " }"
+>       . str "{ " . showToken s . str " }"
+
+>   showToken (TokenFixed s) = str s
+>   showToken (TokenWithValue e) = str $ substExpressionWithHole e "$$"
 
 >   showNonTerminals
 >       = banner "Non-terminals"


### PR DESCRIPTION
Instead of deferring the handling of `$$` to the backends, properly parse the `$$` syntax up front, and store the result in the AST.

Note that the GLR backend was improperly substituting the `$$` twice. Now that we have better types, this was surfaced as type error, and then removed.

Fixes #295