### PR TITLE
Do not use Prelude; concoct our own Happy_Prelude alias (#325)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for Happy
 
+## 2.1.2
+
+Fix a breaking change (#325) introduced by the previous fix for #131.
+Prelude is no longer used by Happy.
+
 ## 2.1.1
 
 This release fixes two breaking changes:

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -66,9 +66,6 @@ This section is optional, but if included takes the following form:
 
 The Haskell module header contains the module name, exports, and imports.
 No other code is allowed in the header—this is because Happy may need to include its own ``import`` statements directly after the user defined header.
-Do note that Happy relies on ``Prelude`` from ``base`` being in scope qualified.
-Users who hide functions from ``Prelude`` or redefine it to use a custom prelude
-must also ``import qualified "base" Prelude`` for Happy.
 
 .. _sec-directives:
 

--- a/happy.cabal
+++ b/happy.cabal
@@ -1,5 +1,5 @@
 name: happy
-version: 2.1.1
+version: 2.1.2
 license: BSD2
 license-file: LICENSE
 copyright: (c) Andy Gill, Simon Marlow
@@ -139,7 +139,7 @@ executable happy
                  array,
                  containers >= 0.4.2,
                  mtl >= 2.2.1,
-                 happy-lib == 2.1.1
+                 happy-lib == 2.1.2
 
   default-language: Haskell98
   default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns

--- a/lib/backend-lalr/src/Happy/Backend/LALR.hs
+++ b/lib/backend-lalr/src/Happy/Backend/LALR.hs
@@ -19,7 +19,7 @@ magicFilter magicName = case magicName of
       in filter_output
 
 importsToInject :: Bool -> String
-importsToInject debug = concat ["\n", import_array, import_list, import_bits, import_glaexts, debug_imports, applicative_imports]
+importsToInject debug = concat ["\n", import_prelude, import_array, import_bits, import_glaexts, debug_imports, applicative_imports]
     where
       debug_imports  | debug     = import_debug
                      | otherwise = ""
@@ -28,13 +28,25 @@ importsToInject debug = concat ["\n", import_array, import_list, import_bits, im
       import_glaexts     = "import qualified GHC.Exts as Happy_GHC_Exts\n"
       _import_ghcstack   = "import qualified GHC.Stack as Happy_GHC_Stack\n"
       import_array       = "import qualified Data.Array as Happy_Data_Array\n"
-      import_list        = "import qualified Data.List as Happy_Data_List\n"
       import_bits        = "import qualified Data.Bits as Bits\n"
       import_debug       = "import qualified System.IO as Happy_System_IO\n" ++
                            "import qualified System.IO.Unsafe as Happy_System_IO_Unsafe\n" ++
                            "import qualified Debug.Trace as Happy_Debug_Trace\n"
       import_applicative = "import Control.Applicative(Applicative(..))\n" ++
                            "import Control.Monad (ap)\n"
+      import_prelude     = unlines $ map (\ x -> unwords ["import qualified", x, "as Happy_Prelude"]) $
+        [ "Data.Function"
+        , "Data.Bool"
+        , "Data.Function"
+        , "Data.Maybe"
+        , "Data.Int"
+        , "Data.String"
+        , "Data.List"
+        , "Control.Monad"
+        , "Text.Show"
+        , "GHC.Num"
+        , "GHC.Err"
+        ]
 
 langExtsToInject :: [String]
 langExtsToInject = ["MagicHash", "BangPatterns", "TypeSynonymInstances", "FlexibleInstances", "PatternGuards", "NoStrictData", "UnboxedTuples", "PartialTypeSignatures"]

--- a/lib/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
+++ b/lib/backend-lalr/src/Happy/Backend/LALR/ProduceCode.lhs
@@ -218,7 +218,7 @@ example where this matters.
 >     | otherwise
 >       = str "data HappyAbsSyn " . str_tyvars
 >       . str "\n" . indent . str "= HappyTerminal " . token
->       . str "\n" . indent . str "| HappyErrorToken Prelude.Int\n"
+>       . str "\n" . indent . str "| HappyErrorToken Happy_Prelude.Int\n"
 >       . interleave "\n"
 >         [ str "" . indent . str "| " . makeAbsSynCon n . strspace . typeParam n ty
 >         | (n, ty) <- assocs nt_types,
@@ -381,7 +381,7 @@ The token conversion function.
 >             . str "\\i tk -> " . doAction . str " sts stk)\n"
 >       . str "\n"
 >       . str "happyReport " . eofTok . str " tk explist resume tks = happyReport' tks explist resume\n"
->       . str "happyReport _ tk explist resume tks = happyReport' (tk:tks) explist (\\tks -> resume (Prelude.tail tks))\n"
+>       . str "happyReport _ tk explist resume tks = happyReport' (tk:tks) explist (\\tks -> resume (Happy_Prelude.tail tks))\n"
 >             -- when the token is EOF, tk == _|_ (notHappyAtAll)
 >             -- so we must not pass it to happyReport'
 >       . str "\n";
@@ -488,9 +488,9 @@ machinery to discard states in the parser...
 >       . produceReduceArray
 >       . produceRuleArray
 >       . produceCatchStates
->       . str "happy_n_terms = " . shows n_terminals . str " :: Prelude.Int\n"
->       . str "happy_n_nonterms = " . shows n_nonterminals . str " :: Prelude.Int\n\n"
->       . str "happy_n_starts = " . shows n_starts . str " :: Prelude.Int\n\n"
+>       . str "happy_n_terms = " . shows n_terminals . str " :: Happy_Prelude.Int\n"
+>       . str "happy_n_nonterms = " . shows n_nonterminals . str " :: Happy_Prelude.Int\n\n"
+>       . str "happy_n_starts = " . shows n_starts . str " :: Happy_Prelude.Int\n\n"
 >
 >    produceTokToStringList
 >       = str "{-# NOINLINE happyTokenStrings #-}\n"
@@ -553,7 +553,7 @@ action array indexed by (terminal * last_state) + state
 >    n_rules = length prods - 1 :: Int
 >
 >    produceCatchStates
->       = str "happyCatchStates :: [Prelude.Int]\n"
+>       = str "happyCatchStates :: [Happy_Prelude.Int]\n"
 >       . str "happyCatchStates = " . shows catch_states . str "\n\n"
 
 >    showInt i = shows i . showChar '#'
@@ -599,12 +599,12 @@ outlaw them inside { }
 >            str "newtype HappyIdentity a = HappyIdentity a\n"
 >          . str "happyIdentity = HappyIdentity\n"
 >          . str "happyRunIdentity (HappyIdentity a) = a\n\n"
->          . str "instance Prelude.Functor HappyIdentity where\n"
+>          . str "instance Happy_Prelude.Functor HappyIdentity where\n"
 >          . str "    fmap f (HappyIdentity a) = HappyIdentity (f a)\n\n"
 >          . str "instance Applicative HappyIdentity where\n"
 >          . str "    pure  = HappyIdentity\n"
 >          . str "    (<*>) = ap\n"
->          . str "instance Prelude.Monad HappyIdentity where\n"
+>          . str "instance Happy_Prelude.Monad HappyIdentity where\n"
 >          . str "    return = pure\n"
 >          . str "    (HappyIdentity p) >>= q = q p\n\n"
 
@@ -652,7 +652,7 @@ MonadStuff:
 >                . str " a\n"
 >                . str "happyReport' :: " . pcont . str " => "
 >                . str "[" . token . str "] -> "
->                . str "[Prelude.String] -> ("
+>                . str "[Happy_Prelude.String] -> ("
 >                . str "[" . token . str "] -> "
 >                . ptyAt (str "a") . str ") -> "
 >                . ptyAt (str "a")
@@ -684,7 +684,7 @@ MonadStuff:
 >                      . str "\n"
 >                  reduceArrSig =
 >                        str "happyReduceArr :: " . pcont
->                      . str " => Happy_Data_Array.Array Prelude.Int (" . intMaybeHash
+>                      . str " => Happy_Data_Array.Array Happy_Prelude.Int (" . intMaybeHash
 >                      . str " -> " . str token_type' . str " -> " . intMaybeHash
 >                      . str " -> Happy_IntList -> HappyStk " . happyAbsSyn
 >                      . str " -> " . ptyAt happyAbsSyn . str ")\n"
@@ -699,7 +699,7 @@ MonadStuff:
 >                . str "happyReturn1 = happyReturn\n"
 >                . str "happyReport' :: " . pcont . str " => "
 >                . token . str " -> "
->                . str "[Prelude.String] -> "
+>                . str "[Happy_Prelude.String] -> "
 >                . ptyAt (str "a") . str " -> "
 >                . ptyAt (str "a")
 >                . str "\n"
@@ -726,7 +726,7 @@ have a special code path for `OldExpected`.
 >    callReportError = -- this one wraps around report_error_handler to expose a unified interface
 >       str "(\\tokens expected resume -> " .
 >       (if use_monad then str ""
->                     else str "HappyIdentity Prelude.$ ") .
+>                     else str "HappyIdentity Happy_Prelude.$ ") .
 >       report_error_handler .
 >       (case error_expected' of
 >          OldExpected -> str " (tokens, expected)"  -- back-compat for %errorhandlertype
@@ -744,7 +744,7 @@ have a special code path for `OldExpected`.
 >       ResumptiveErrorHandler _abort report -> brack report
 >    abort_handler = case error_handler' of
 >       ResumptiveErrorHandler abort _report -> abort
->       _                                    -> "Prelude.error \"Called abort handler in non-resumptive parser\""
+>       _                                    -> "Happy_Prelude.error \"Called abort handler in non-resumptive parser\""
 
 >    reduceArrElem n
 >      = str "" . indent . str "(" . shows n . str " , "
@@ -799,21 +799,21 @@ have a special code path for `OldExpected`.
 >         . str "do { "
 >         . str "f <- do_" . str name . str "; "
 >         . str "let { (conds,attrs) = f happyEmptyAttrs } in do { "
->         . str "Prelude.sequence_ conds; "
->         . str "Prelude.return (". str defaultAttr . str " attrs) }}"
+>         . str "Happy_Prelude.sequence_ conds; "
+>         . str "Happy_Prelude.return (". str defaultAttr . str " attrs) }}"
 >       monadAE name
 >         = str name . str " toks = "
 >         . str "do { "
 >         . str "f <- do_" . str name . str " toks; "
 >         . str "let { (conds,attrs) = f happyEmptyAttrs } in do { "
->         . str "Prelude.sequence_ conds; "
->         . str "Prelude.return (". str defaultAttr . str " attrs) }}"
+>         . str "Happy_Prelude.sequence_ conds; "
+>         . str "Happy_Prelude.return (". str defaultAttr . str " attrs) }}"
 >       regularAE name
 >         = str name . str " toks = "
 >         . str "let { "
 >         . str "f = do_" . str name . str " toks; "
 >         . str "(conds,attrs) = f happyEmptyAttrs; "
->         . str "x = Prelude.foldr Prelude.seq attrs conds; "
+>         . str "x = Happy_Prelude.foldr Happy_GHC_Exts.seq attrs conds; "
 >         . str "} in (". str defaultAttr . str " x)"
 
 ----------------------------------------------------------------------------
@@ -830,7 +830,7 @@ have a special code path for `OldExpected`.
 >   where attributes'  = foldl1 (\x y -> x . str ", " . y) $ map formatAttribute attrs
 >         formatAttribute (ident,typ) = str ident . str " :: " . str typ
 >         attrsErrors = foldl1 (\x y -> x . str ", " . y) $ map attrError attrs
->         attrError (ident,_) = str ident . str " = Prelude.error \"invalid reference to attribute '" . str ident . str "'\""
+>         attrError (ident,_) = str ident . str " = Happy_Prelude.error \"invalid reference to attribute '" . str ident . str "'\""
 >         attrHeader =
 >             case attributeType of
 >             [] -> str "HappyAttributes"

--- a/lib/data/HappyTemplate.hs
+++ b/lib/data/HappyTemplate.hs
@@ -8,9 +8,9 @@
 #include "MachDeps.h"
 
 -- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
-#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Prelude.Bool)
-#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Prelude.Bool)
-#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Prelude.Bool)
+#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Happy_Prelude.Bool)
+#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Happy_Prelude.Bool)
+#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Happy_Prelude.Bool)
 #define PLUS(n,m) (n Happy_GHC_Exts.+# m)
 #define MINUS(n,m) (n Happy_GHC_Exts.-# m)
 #define TIMES(n,m) (n Happy_GHC_Exts.*# m)
@@ -34,10 +34,10 @@ data Happy_IntList = HappyCons Happy_Int Happy_IntList
 #endif
 
 #if defined(HAPPY_DEBUG)
-#  define DEBUG_TRACE(s)    (happyTrace (s)) Prelude.$
-happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Prelude.$ do
+#  define DEBUG_TRACE(s)    (happyTrace (s)) Happy_Prelude.$
+happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Happy_Prelude.$ do
     Happy_System_IO.hPutStr Happy_System_IO.stderr string
-    Prelude.return expr
+    Happy_Prelude.return expr
 #else
 #  define DEBUG_TRACE(s)    {- nothing -}
 #endif
@@ -65,23 +65,23 @@ happyAccept j tk st sts (HappyStk ans _) =
 -- Arrays only: do the next action
 
 happyDoAction i tk st =
-  DEBUG_TRACE("state: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++
-              ",\ttoken: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++
+  DEBUG_TRACE("state: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++
+              ",\ttoken: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++
               ",\taction: ")
   case happyDecodeAction (happyNextAction i st) of
     HappyFail             -> DEBUG_TRACE("failing.\n")
                              happyFail i tk st
     HappyAccept           -> DEBUG_TRACE("accept.\n")
                              happyAccept i tk st
-    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# rule) Prelude.++ ")")
+    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# rule) Happy_Prelude.++ ")")
                              (happyReduceArr Happy_Data_Array.! (Happy_GHC_Exts.I# rule)) i tk st
-    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
                              happyShift new_state i tk st
 
 {-# INLINE happyNextAction #-}
 happyNextAction i st = case happyIndexActionTable i st of
-  Prelude.Just (Happy_GHC_Exts.I# act) -> act
-  Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
+  Happy_Prelude.Just (Happy_GHC_Exts.I# act) -> act
+  Happy_Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
 
 {-# INLINE happyIndexActionTable #-}
 happyIndexActionTable i st
@@ -89,9 +89,9 @@ happyIndexActionTable i st
   -- i >= 0:   Guard against INVALID_TOK (do the default action, which ultimately errors)
   -- off >= 0: Otherwise it's a default action
   -- equality check: Ensure that the entry in the compressed array is owned by st
-  = Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
-  | Prelude.otherwise
-  = Prelude.Nothing
+  = Happy_Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
+  | Happy_Prelude.otherwise
+  = Happy_Prelude.Nothing
   where
     off = PLUS(happyIndexOffAddr happyActOffsets st, i)
 
@@ -100,14 +100,14 @@ data HappyAction
   | HappyAccept
   | HappyReduce Happy_Int -- rule number
   | HappyShift Happy_Int  -- new state
-  deriving Prelude.Show
+  deriving Happy_Prelude.Show
 
 {-# INLINE happyDecodeAction #-}
 happyDecodeAction :: Happy_Int -> HappyAction
 happyDecodeAction  0#                        = HappyFail
 happyDecodeAction -1#                        = HappyAccept
 happyDecodeAction action | LT(action, 0#)    = HappyReduce NEGATE(PLUS(action, 1#))
-                         | Prelude.otherwise = HappyShift MINUS(action, 1#)
+                         | Happy_Prelude.otherwise = HappyShift MINUS(action, 1#)
 
 {-# INLINE happyIndexGotoTable #-}
 happyIndexGotoTable nt st = happyIndexOffAddr happyTable off
@@ -206,7 +206,7 @@ happyDropStk n  (x `HappyStk` xs) = happyDropStk MINUS(n,(1#::Happy_Int)) xs
 -- Moving to a new state after a reduction
 
 happyGoto nt j tk st =
-   DEBUG_TRACE(", goto state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+   DEBUG_TRACE(", goto state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
    happyDoAction j tk new_state
   where new_state = happyIndexGotoTable nt st
 
@@ -256,8 +256,8 @@ It is best understood by example. Consider
 Exp :: { String }
 Exp : '1'                { "1" }
     | catch              { "catch" }
-    | Exp '+' Exp %shift { $1 Prelude.++ " + " Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
-    | '(' Exp ')'        { "(" Prelude.++ $2 Prelude.++ ")" }
+    | Exp '+' Exp %shift { $1 Happy_Prelude.++ " + " Happy_Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
+    | '(' Exp ')'        { "(" Happy_Prelude.++ $2 Happy_Prelude.++ ")" }
 
 The idea of the use of `catch` here is that upon encountering a parse error
 during expression parsing, we can gracefully degrade using the `catch` rule,
@@ -365,73 +365,73 @@ happyFixupFailed tk st sts (x `HappyStk` stk) =
 happyResume i tk st sts stk = pop_items [] st sts stk
   where
     !(Happy_GHC_Exts.I# n_starts) = happy_n_starts   -- this is to test whether we have a start token
-    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Prelude.- 1   -- this is the token number of the EOF token
-    happy_list_to_list :: Happy_IntList -> [Prelude.Int]
+    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Happy_Prelude.- 1   -- this is the token number of the EOF token
+    happy_list_to_list :: Happy_IntList -> [Happy_Prelude.Int]
     happy_list_to_list (HappyCons st sts)
       | LT(st, n_starts)
       = [(Happy_GHC_Exts.I# st)]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = (Happy_GHC_Exts.I# st) : happy_list_to_list sts
 
     -- See (1) of Note [happyResume]
     pop_items catch_frames st sts stk
       | LT(st, n_starts)
-      = DEBUG_TRACE("reached start state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", ")
-        if Prelude.null catch_frames_new
+      = DEBUG_TRACE("reached start state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", ")
+        if Happy_Prelude.null catch_frames_new
           then DEBUG_TRACE("no resumption.\n")
                happyAbort
-          else DEBUG_TRACE("now discard input, trying to anchor in states " Prelude.++ Prelude.show (Prelude.map (happy_list_to_list . Prelude.fst) (Prelude.reverse catch_frames_new)) Prelude.++ ".\n")
-               discard_input_until_exp i tk (Prelude.reverse catch_frames_new)
+          else DEBUG_TRACE("now discard input, trying to anchor in states " Happy_Prelude.++ Happy_Prelude.show (Happy_Prelude.map (happy_list_to_list . Happy_Prelude.fst) (Happy_Prelude.reverse catch_frames_new)) Happy_Prelude.++ ".\n")
+               discard_input_until_exp i tk (Happy_Prelude.reverse catch_frames_new)
       | (HappyCons st1 sts1) <- sts, _ `HappyStk` stk1 <- stk
       = pop_items catch_frames_new st1 sts1 stk1
       where
         !catch_frames_new
           | HappyShift new_state <- happyDecodeAction (happyNextAction CATCH_TOK st)
-          , DEBUG_TRACE("can shift catch token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", into state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
-            Prelude.null (Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
+          , DEBUG_TRACE("can shift catch token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", into state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
+            Happy_Prelude.null (Happy_Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
           = (HappyCons new_state (HappyCons st sts), MK_ERROR_TOKEN(i) `HappyStk` stk):catch_frames -- MK_ERROR_TOKEN(i) is just some dummy that should not be accessed by user code
-          | Prelude.otherwise
-          = DEBUG_TRACE("already shifted or can't shift catch in " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ "\n")
+          | Happy_Prelude.otherwise
+          = DEBUG_TRACE("already shifted or can't shift catch in " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ "\n")
             catch_frames
 
     -- See (2) of Note [happyResume]
     discard_input_until_exp i tk catch_frames
-      | Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
-      = DEBUG_TRACE("found expected token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ " after shifting from " Prelude.++ Prelude.show (Happy_GHC_Exts.I# catch_st) Prelude.++ ": " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
+      = DEBUG_TRACE("found expected token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ " after shifting from " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# catch_st) Happy_Prelude.++ ": " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyDoAction i tk st (HappyCons catch_st sts) catch_frame
       | EQ(i,eof_i) -- is i EOF?
       = DEBUG_TRACE("reached EOF, cannot resume. abort parse :(\n")
         happyAbort
-      | Prelude.otherwise
-      = DEBUG_TRACE("discard token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.otherwise
+      = DEBUG_TRACE("discard token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyLex (\eof_tk -> discard_input_until_exp eof_i eof_tk catch_frames) -- eof
                  (\i tk   -> discard_input_until_exp i tk catch_frames)         -- not eof
 
-    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Prelude.Nothing
+    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Happy_Prelude.Nothing
     some_catch_state_shifts i catch_frames@(((HappyCons st sts),_):_) = try_head i st sts catch_frames
       where
         try_head i st sts catch_frames = -- PRECONDITION: head catch_frames = (HappyCons st sts)
-          DEBUG_TRACE("trying token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ " in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ": ")
+          DEBUG_TRACE("trying token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ " in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ": ")
           case happyDecodeAction (happyNextAction i st) of
-            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Prelude.tail catch_frames)
-            HappyAccept   -> DEBUG_TRACE("accept.\n") Prelude.Just (Prelude.head catch_frames)
-            HappyShift _  -> DEBUG_TRACE("shift.\n")  Prelude.Just (Prelude.head catch_frames)
+            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Happy_Prelude.tail catch_frames)
+            HappyAccept   -> DEBUG_TRACE("accept.\n") Happy_Prelude.Just (Happy_Prelude.head catch_frames)
+            HappyShift _  -> DEBUG_TRACE("shift.\n")  Happy_Prelude.Just (Happy_Prelude.head catch_frames)
             HappyReduce r -> case happySimulateReduce r st sts of
               (HappyCons st1 sts1) -> try_head i st1 sts1 catch_frames
 
 happySimulateReduce r st sts =
-  DEBUG_TRACE("simulate reduction of rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# r) Prelude.++ ", ")
+  DEBUG_TRACE("simulate reduction of rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# r) Happy_Prelude.++ ", ")
   let (# nt, len #) = happyIndexRuleArr r in
-  DEBUG_TRACE("nt " Prelude.++ Prelude.show (Happy_GHC_Exts.I# nt) Prelude.++ ", len: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# len) Prelude.++ ", new_st ")
+  DEBUG_TRACE("nt " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# nt) Happy_Prelude.++ ", len: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# len) Happy_Prelude.++ ", new_st ")
   let !(sts1@(HappyCons st1 _)) = happyDrop len (HappyCons st sts)
       new_st = happyIndexGotoTable nt st1 in
-  DEBUG_TRACE(Prelude.show (Happy_GHC_Exts.I# new_st) Prelude.++ ".\n")
+  DEBUG_TRACE(Happy_Prelude.show (Happy_GHC_Exts.I# new_st) Happy_Prelude.++ ".\n")
   (HappyCons new_st sts1)
 
-happyTokenToString :: Prelude.Int -> Prelude.String
-happyTokenToString i = happyTokenStrings Prelude.!! (i Prelude.- 2) -- 2: errorTok, catchTok
+happyTokenToString :: Happy_Prelude.Int -> Happy_Prelude.String
+happyTokenToString i = happyTokenStrings Happy_Prelude.!! (i Happy_Prelude.- 2) -- 2: errorTok, catchTok
 
-happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
+happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Happy_Prelude.String]
 -- Upon a parse error, we want to suggest tokens that are expected in that
 -- situation. This function computes such tokens.
 -- It works by examining the top of the state stack.
@@ -442,15 +442,15 @@ happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
 -- returned.
 happyExpectedTokens st sts =
   DEBUG_TRACE("constructing expected tokens.\n")
-  Prelude.map happyTokenToString (search_shifts st sts [])
+  Happy_Prelude.map happyTokenToString (search_shifts st sts [])
   where
-    search_shifts st sts shifts = Prelude.foldr (add_action st sts) shifts (distinct_actions st)
+    search_shifts st sts shifts = Happy_Prelude.foldr (add_action st sts) shifts (distinct_actions st)
     add_action st sts (Happy_GHC_Exts.I# i, Happy_GHC_Exts.I# act) shifts =
-      DEBUG_TRACE("found action in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", input " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ ", " Prelude.++ Prelude.show (happyDecodeAction act) Prelude.++ "\n")
+      DEBUG_TRACE("found action in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", input " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ ", " Happy_Prelude.++ Happy_Prelude.show (happyDecodeAction act) Happy_Prelude.++ "\n")
       case happyDecodeAction act of
         HappyFail     -> shifts
         HappyAccept   -> shifts -- This would always be %eof or error... Not helpful
-        HappyShift _  -> Happy_Data_List.insert (Happy_GHC_Exts.I# i) shifts
+        HappyShift _  -> Happy_Prelude.insert (Happy_GHC_Exts.I# i) shifts
         HappyReduce r -> case happySimulateReduce r st sts of
           (HappyCons st1 sts1) -> search_shifts st1 sts1 shifts
     distinct_actions st
@@ -465,13 +465,13 @@ happyExpectedTokens st sts =
       , GTE(off_i,0#)
       , EQ(happyIndexOffAddr happyCheck off_i,i)
       = [(Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off_i))]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = []
 
 -- Internal happy errors:
 
 notHappyAtAll :: a
-notHappyAtAll = Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
+notHappyAtAll = Happy_Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
 
 -----------------------------------------------------------------------------
 -- Hack to get the typechecker to accept our action functions
@@ -483,11 +483,11 @@ happyTcHack x y = y
 -----------------------------------------------------------------------------
 -- Seq-ing.  If the --strict flag is given, then Happy emits
 --      happySeq = happyDoSeq
--- Prelude.otherwise it emits
+-- otherwise it emits
 --      happySeq = happyDontSeq
 
 happyDoSeq, happyDontSeq :: a -> b -> b
-happyDoSeq   a b = a `Prelude.seq` b
+happyDoSeq   a b = a `Happy_GHC_Exts.seq` b
 happyDontSeq a b = b
 
 -----------------------------------------------------------------------------

--- a/lib/frontend/boot-src/Parser.ly
+++ b/lib/frontend/boot-src/Parser.ly
@@ -116,8 +116,8 @@ The parser.
 >       | spec_partial id optStart      { TokenName $2 $3 True  }
 >       | spec_imported_identity        { TokenImportedIdentity }
 >       | spec_lexer code code          { TokenLexer $2 $3 }
->       | spec_monad code               { TokenMonad "()" $2 "Prelude.>>=" "Prelude.return" }
->       | spec_monad code code          { TokenMonad $2 $3 "Prelude.>>=" "Prelude.return" }
+>       | spec_monad code               { TokenMonad "()" $2 "Happy_Prelude.>>=" "Happy_Prelude.return" }
+>       | spec_monad code code          { TokenMonad $2 $3 "Happy_Prelude.>>=" "Happy_Prelude.return" }
 >       | spec_monad code code code     { TokenMonad "()" $2 $3 $4 }
 >       | spec_monad code code code code        { TokenMonad $2 $3 $4 $5 }
 >       | spec_nonassoc ids             { TokenNonassoc $2 }

--- a/lib/frontend/src/Happy/Frontend/AbsSyn.lhs
+++ b/lib/frontend/src/Happy/Frontend/AbsSyn.lhs
@@ -111,7 +111,7 @@ generate some error messages.
 > getMonad ds
 >       = case [ (True,a,b,c,d) | (TokenMonad a b c d) <- ds ] of
 >               [t] -> t
->               []  -> (False,"()","HappyIdentity","Prelude.>>=","Prelude.return")
+>               []  -> (False,"()","HappyIdentity","Happy_Prelude.>>=","Happy_Prelude.return")
 >               _   -> error "multiple monad directives"
 
 > getTokenSpec :: [Directive t] -> [(t, TokenSpec)]

--- a/lib/frontend/src/Happy/Frontend/AttrGrammar/Parser.hs
+++ b/lib/frontend/src/Happy/Frontend/AttrGrammar/Parser.hs
@@ -16,14 +16,23 @@ module Happy.Frontend.AttrGrammar.Parser (agParser) where
 import Happy.Frontend.ParseMonad.Class
 import Happy.Frontend.ParseMonad
 import Happy.Frontend.AttrGrammar
+import qualified Data.Bool as Happy_Prelude
+import qualified Data.Function as Happy_Prelude
+import qualified Data.Maybe as Happy_Prelude
+import qualified Data.Int as Happy_Prelude
+import qualified Data.String as Happy_Prelude
+import qualified Data.List as Happy_Prelude
+import qualified Control.Monad as Happy_Prelude
+import qualified Text.Show as Happy_Prelude
+import qualified GHC.Num as Happy_Prelude
+import qualified GHC.Err as Happy_Prelude
 import qualified Data.Array as Happy_Data_Array
-import qualified Data.List as Happy_Data_List
 import qualified Data.Bits as Bits
 import qualified GHC.Exts as Happy_GHC_Exts
 import Control.Applicative(Applicative(..))
 import Control.Monad (ap)
 
--- parser produced by Happy Version 3.0
+-- parser produced by Happy Version 2.1.1
 
 newtype HappyAbsSyn  = HappyAbsSyn HappyAny
 #if __GLASGOW_HASKELL__ >= 607
@@ -121,13 +130,13 @@ happyReduceArr = Happy_Data_Array.array (1, 23) [
 happyRuleArr :: HappyAddr
 happyRuleArr = HappyA# "\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x02\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00"#
 
-happyCatchStates :: [Prelude.Int]
+happyCatchStates :: [Happy_Prelude.Int]
 happyCatchStates = []
 
-happy_n_terms = 12 :: Prelude.Int
-happy_n_nonterms = 5 :: Prelude.Int
+happy_n_terms = 12 :: Happy_Prelude.Int
+happy_n_nonterms = 5 :: Happy_Prelude.Int
 
-happy_n_starts = 1 :: Prelude.Int
+happy_n_starts = 1 :: Happy_Prelude.Int
 
 happyReduce_1 :: () => Happy_GHC_Exts.Int# -> AgToken -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> P (HappyAbsSyn )
 happyReduce_1 = happySpecReduce_1  0# happyReduction_1
@@ -383,27 +392,27 @@ happyReport _ = happyReport'
 
 
 happyThen :: () => (P a) -> (a -> (P b)) -> (P b)
-happyThen = (Prelude.>>=)
+happyThen = (Happy_Prelude.>>=)
 happyReturn :: () => a -> (P a)
-happyReturn = (Prelude.return)
+happyReturn = (Happy_Prelude.return)
 happyParse :: () => Happy_GHC_Exts.Int# -> P (HappyAbsSyn )
 
 happyNewToken :: () => Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn ))
 
 happyDoAction :: () => Happy_GHC_Exts.Int# -> AgToken -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn ))
 
-happyReduceArr :: () => Happy_Data_Array.Array Prelude.Int (Happy_GHC_Exts.Int# -> AgToken -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn )))
+happyReduceArr :: () => Happy_Data_Array.Array Happy_Prelude.Int (Happy_GHC_Exts.Int# -> AgToken -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn )))
 
 happyThen1 :: () => P a -> (a -> P b) -> P b
 happyThen1 = happyThen
 happyFmap1 f m = happyThen m (\a -> happyReturn (f a))
 happyReturn1 :: () => a -> (P a)
 happyReturn1 = happyReturn
-happyReport' :: () => (AgToken) -> [Prelude.String] -> (P a) -> (P a)
+happyReport' :: () => (AgToken) -> [Happy_Prelude.String] -> (P a) -> (P a)
 happyReport' = (\tokens expected resume -> happyError)
 
 happyAbort :: () => (P a)
-happyAbort = Prelude.error "Called abort handler in non-resumptive parser"
+happyAbort = Happy_Prelude.error "Called abort handler in non-resumptive parser"
 
 agParser = happySomeParser where
  happySomeParser = happyThen (happyParse 0#) (\x -> happyReturn (let {(HappyWrap5 x') = happyOut5 x} in x'))
@@ -424,9 +433,9 @@ happyError = failP (\l -> show l ++ ": Parse error\n")
 #include "MachDeps.h"
 
 -- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
-#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Prelude.Bool)
-#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Prelude.Bool)
-#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Prelude.Bool)
+#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Happy_Prelude.Bool)
+#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Happy_Prelude.Bool)
+#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Happy_Prelude.Bool)
 #define PLUS(n,m) (n Happy_GHC_Exts.+# m)
 #define MINUS(n,m) (n Happy_GHC_Exts.-# m)
 #define TIMES(n,m) (n Happy_GHC_Exts.*# m)
@@ -450,10 +459,10 @@ data Happy_IntList = HappyCons Happy_Int Happy_IntList
 #endif
 
 #if defined(HAPPY_DEBUG)
-#  define DEBUG_TRACE(s)    (happyTrace (s)) Prelude.$
-happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Prelude.$ do
+#  define DEBUG_TRACE(s)    (happyTrace (s)) Happy_Prelude.$
+happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Happy_Prelude.$ do
     Happy_System_IO.hPutStr Happy_System_IO.stderr string
-    Prelude.return expr
+    Happy_Prelude.return expr
 #else
 #  define DEBUG_TRACE(s)    {- nothing -}
 #endif
@@ -481,23 +490,23 @@ happyAccept j tk st sts (HappyStk ans _) =
 -- Arrays only: do the next action
 
 happyDoAction i tk st =
-  DEBUG_TRACE("state: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++
-              ",\ttoken: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++
+  DEBUG_TRACE("state: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++
+              ",\ttoken: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++
               ",\taction: ")
   case happyDecodeAction (happyNextAction i st) of
     HappyFail             -> DEBUG_TRACE("failing.\n")
                              happyFail i tk st
     HappyAccept           -> DEBUG_TRACE("accept.\n")
                              happyAccept i tk st
-    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# rule) Prelude.++ ")")
+    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# rule) Happy_Prelude.++ ")")
                              (happyReduceArr Happy_Data_Array.! (Happy_GHC_Exts.I# rule)) i tk st
-    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
                              happyShift new_state i tk st
 
 {-# INLINE happyNextAction #-}
 happyNextAction i st = case happyIndexActionTable i st of
-  Prelude.Just (Happy_GHC_Exts.I# act) -> act
-  Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
+  Happy_Prelude.Just (Happy_GHC_Exts.I# act) -> act
+  Happy_Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
 
 {-# INLINE happyIndexActionTable #-}
 happyIndexActionTable i st
@@ -505,9 +514,9 @@ happyIndexActionTable i st
   -- i >= 0:   Guard against INVALID_TOK (do the default action, which ultimately errors)
   -- off >= 0: Otherwise it's a default action
   -- equality check: Ensure that the entry in the compressed array is owned by st
-  = Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
-  | Prelude.otherwise
-  = Prelude.Nothing
+  = Happy_Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
+  | Happy_Prelude.otherwise
+  = Happy_Prelude.Nothing
   where
     off = PLUS(happyIndexOffAddr happyActOffsets st, i)
 
@@ -516,14 +525,14 @@ data HappyAction
   | HappyAccept
   | HappyReduce Happy_Int -- rule number
   | HappyShift Happy_Int  -- new state
-  deriving Prelude.Show
+  deriving Happy_Prelude.Show
 
 {-# INLINE happyDecodeAction #-}
 happyDecodeAction :: Happy_Int -> HappyAction
 happyDecodeAction  0#                        = HappyFail
 happyDecodeAction -1#                        = HappyAccept
 happyDecodeAction action | LT(action, 0#)    = HappyReduce NEGATE(PLUS(action, 1#))
-                         | Prelude.otherwise = HappyShift MINUS(action, 1#)
+                         | Happy_Prelude.otherwise = HappyShift MINUS(action, 1#)
 
 {-# INLINE happyIndexGotoTable #-}
 happyIndexGotoTable nt st = happyIndexOffAddr happyTable off
@@ -622,7 +631,7 @@ happyDropStk n  (x `HappyStk` xs) = happyDropStk MINUS(n,(1#::Happy_Int)) xs
 -- Moving to a new state after a reduction
 
 happyGoto nt j tk st =
-   DEBUG_TRACE(", goto state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+   DEBUG_TRACE(", goto state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
    happyDoAction j tk new_state
   where new_state = happyIndexGotoTable nt st
 
@@ -672,8 +681,8 @@ It is best understood by example. Consider
 Exp :: { String }
 Exp : '1'                { "1" }
     | catch              { "catch" }
-    | Exp '+' Exp %shift { $1 Prelude.++ " + " Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
-    | '(' Exp ')'        { "(" Prelude.++ $2 Prelude.++ ")" }
+    | Exp '+' Exp %shift { $1 Happy_Prelude.++ " + " Happy_Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
+    | '(' Exp ')'        { "(" Happy_Prelude.++ $2 Happy_Prelude.++ ")" }
 
 The idea of the use of `catch` here is that upon encountering a parse error
 during expression parsing, we can gracefully degrade using the `catch` rule,
@@ -781,73 +790,73 @@ happyFixupFailed tk st sts (x `HappyStk` stk) =
 happyResume i tk st sts stk = pop_items [] st sts stk
   where
     !(Happy_GHC_Exts.I# n_starts) = happy_n_starts   -- this is to test whether we have a start token
-    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Prelude.- 1   -- this is the token number of the EOF token
-    happy_list_to_list :: Happy_IntList -> [Prelude.Int]
+    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Happy_Prelude.- 1   -- this is the token number of the EOF token
+    happy_list_to_list :: Happy_IntList -> [Happy_Prelude.Int]
     happy_list_to_list (HappyCons st sts)
       | LT(st, n_starts)
       = [(Happy_GHC_Exts.I# st)]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = (Happy_GHC_Exts.I# st) : happy_list_to_list sts
 
     -- See (1) of Note [happyResume]
     pop_items catch_frames st sts stk
       | LT(st, n_starts)
-      = DEBUG_TRACE("reached start state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", ")
-        if Prelude.null catch_frames_new
+      = DEBUG_TRACE("reached start state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", ")
+        if Happy_Prelude.null catch_frames_new
           then DEBUG_TRACE("no resumption.\n")
                happyAbort
-          else DEBUG_TRACE("now discard input, trying to anchor in states " Prelude.++ Prelude.show (Prelude.map (happy_list_to_list . Prelude.fst) (Prelude.reverse catch_frames_new)) Prelude.++ ".\n")
-               discard_input_until_exp i tk (Prelude.reverse catch_frames_new)
+          else DEBUG_TRACE("now discard input, trying to anchor in states " Happy_Prelude.++ Happy_Prelude.show (Happy_Prelude.map (happy_list_to_list . Happy_Prelude.fst) (Happy_Prelude.reverse catch_frames_new)) Happy_Prelude.++ ".\n")
+               discard_input_until_exp i tk (Happy_Prelude.reverse catch_frames_new)
       | (HappyCons st1 sts1) <- sts, _ `HappyStk` stk1 <- stk
       = pop_items catch_frames_new st1 sts1 stk1
       where
         !catch_frames_new
           | HappyShift new_state <- happyDecodeAction (happyNextAction CATCH_TOK st)
-          , DEBUG_TRACE("can shift catch token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", into state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
-            Prelude.null (Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
+          , DEBUG_TRACE("can shift catch token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", into state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
+            Happy_Prelude.null (Happy_Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
           = (HappyCons new_state (HappyCons st sts), MK_ERROR_TOKEN(i) `HappyStk` stk):catch_frames -- MK_ERROR_TOKEN(i) is just some dummy that should not be accessed by user code
-          | Prelude.otherwise
-          = DEBUG_TRACE("already shifted or can't shift catch in " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ "\n")
+          | Happy_Prelude.otherwise
+          = DEBUG_TRACE("already shifted or can't shift catch in " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ "\n")
             catch_frames
 
     -- See (2) of Note [happyResume]
     discard_input_until_exp i tk catch_frames
-      | Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
-      = DEBUG_TRACE("found expected token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ " after shifting from " Prelude.++ Prelude.show (Happy_GHC_Exts.I# catch_st) Prelude.++ ": " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
+      = DEBUG_TRACE("found expected token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ " after shifting from " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# catch_st) Happy_Prelude.++ ": " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyDoAction i tk st (HappyCons catch_st sts) catch_frame
       | EQ(i,eof_i) -- is i EOF?
       = DEBUG_TRACE("reached EOF, cannot resume. abort parse :(\n")
         happyAbort
-      | Prelude.otherwise
-      = DEBUG_TRACE("discard token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.otherwise
+      = DEBUG_TRACE("discard token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyLex (\eof_tk -> discard_input_until_exp eof_i eof_tk catch_frames) -- eof
                  (\i tk   -> discard_input_until_exp i tk catch_frames)         -- not eof
 
-    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Prelude.Nothing
+    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Happy_Prelude.Nothing
     some_catch_state_shifts i catch_frames@(((HappyCons st sts),_):_) = try_head i st sts catch_frames
       where
         try_head i st sts catch_frames = -- PRECONDITION: head catch_frames = (HappyCons st sts)
-          DEBUG_TRACE("trying token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ " in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ": ")
+          DEBUG_TRACE("trying token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ " in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ": ")
           case happyDecodeAction (happyNextAction i st) of
-            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Prelude.tail catch_frames)
-            HappyAccept   -> DEBUG_TRACE("accept.\n") Prelude.Just (Prelude.head catch_frames)
-            HappyShift _  -> DEBUG_TRACE("shift.\n")  Prelude.Just (Prelude.head catch_frames)
+            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Happy_Prelude.tail catch_frames)
+            HappyAccept   -> DEBUG_TRACE("accept.\n") Happy_Prelude.Just (Happy_Prelude.head catch_frames)
+            HappyShift _  -> DEBUG_TRACE("shift.\n")  Happy_Prelude.Just (Happy_Prelude.head catch_frames)
             HappyReduce r -> case happySimulateReduce r st sts of
               (HappyCons st1 sts1) -> try_head i st1 sts1 catch_frames
 
 happySimulateReduce r st sts =
-  DEBUG_TRACE("simulate reduction of rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# r) Prelude.++ ", ")
+  DEBUG_TRACE("simulate reduction of rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# r) Happy_Prelude.++ ", ")
   let (# nt, len #) = happyIndexRuleArr r in
-  DEBUG_TRACE("nt " Prelude.++ Prelude.show (Happy_GHC_Exts.I# nt) Prelude.++ ", len: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# len) Prelude.++ ", new_st ")
+  DEBUG_TRACE("nt " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# nt) Happy_Prelude.++ ", len: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# len) Happy_Prelude.++ ", new_st ")
   let !(sts1@(HappyCons st1 _)) = happyDrop len (HappyCons st sts)
       new_st = happyIndexGotoTable nt st1 in
-  DEBUG_TRACE(Prelude.show (Happy_GHC_Exts.I# new_st) Prelude.++ ".\n")
+  DEBUG_TRACE(Happy_Prelude.show (Happy_GHC_Exts.I# new_st) Happy_Prelude.++ ".\n")
   (HappyCons new_st sts1)
 
-happyTokenToString :: Prelude.Int -> Prelude.String
-happyTokenToString i = happyTokenStrings Prelude.!! (i Prelude.- 2) -- 2: errorTok, catchTok
+happyTokenToString :: Happy_Prelude.Int -> Happy_Prelude.String
+happyTokenToString i = happyTokenStrings Happy_Prelude.!! (i Happy_Prelude.- 2) -- 2: errorTok, catchTok
 
-happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
+happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Happy_Prelude.String]
 -- Upon a parse error, we want to suggest tokens that are expected in that
 -- situation. This function computes such tokens.
 -- It works by examining the top of the state stack.
@@ -858,15 +867,15 @@ happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
 -- returned.
 happyExpectedTokens st sts =
   DEBUG_TRACE("constructing expected tokens.\n")
-  Prelude.map happyTokenToString (search_shifts st sts [])
+  Happy_Prelude.map happyTokenToString (search_shifts st sts [])
   where
-    search_shifts st sts shifts = Prelude.foldr (add_action st sts) shifts (distinct_actions st)
+    search_shifts st sts shifts = Happy_Prelude.foldr (add_action st sts) shifts (distinct_actions st)
     add_action st sts (Happy_GHC_Exts.I# i, Happy_GHC_Exts.I# act) shifts =
-      DEBUG_TRACE("found action in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", input " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ ", " Prelude.++ Prelude.show (happyDecodeAction act) Prelude.++ "\n")
+      DEBUG_TRACE("found action in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", input " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ ", " Happy_Prelude.++ Happy_Prelude.show (happyDecodeAction act) Happy_Prelude.++ "\n")
       case happyDecodeAction act of
         HappyFail     -> shifts
         HappyAccept   -> shifts -- This would always be %eof or error... Not helpful
-        HappyShift _  -> Happy_Data_List.insert (Happy_GHC_Exts.I# i) shifts
+        HappyShift _  -> Happy_Prelude.insert (Happy_GHC_Exts.I# i) shifts
         HappyReduce r -> case happySimulateReduce r st sts of
           (HappyCons st1 sts1) -> search_shifts st1 sts1 shifts
     distinct_actions st
@@ -881,13 +890,13 @@ happyExpectedTokens st sts =
       , GTE(off_i,0#)
       , EQ(happyIndexOffAddr happyCheck off_i,i)
       = [(Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off_i))]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = []
 
 -- Internal happy errors:
 
 notHappyAtAll :: a
-notHappyAtAll = Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
+notHappyAtAll = Happy_Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
 
 -----------------------------------------------------------------------------
 -- Hack to get the typechecker to accept our action functions
@@ -899,11 +908,11 @@ happyTcHack x y = y
 -----------------------------------------------------------------------------
 -- Seq-ing.  If the --strict flag is given, then Happy emits
 --      happySeq = happyDoSeq
--- Prelude.otherwise it emits
+-- otherwise it emits
 --      happySeq = happyDontSeq
 
 happyDoSeq, happyDontSeq :: a -> b -> b
-happyDoSeq   a b = a `Prelude.seq` b
+happyDoSeq   a b = a `Happy_GHC_Exts.seq` b
 happyDontSeq a b = b
 
 -----------------------------------------------------------------------------

--- a/lib/frontend/src/Happy/Frontend/Parser.hs
+++ b/lib/frontend/src/Happy/Frontend/Parser.hs
@@ -17,14 +17,23 @@ import Happy.Frontend.ParseMonad.Class
 import Happy.Frontend.ParseMonad
 import Happy.Frontend.AbsSyn
 import Happy.Frontend.Lexer
+import qualified Data.Bool as Happy_Prelude
+import qualified Data.Function as Happy_Prelude
+import qualified Data.Maybe as Happy_Prelude
+import qualified Data.Int as Happy_Prelude
+import qualified Data.String as Happy_Prelude
+import qualified Data.List as Happy_Prelude
+import qualified Control.Monad as Happy_Prelude
+import qualified Text.Show as Happy_Prelude
+import qualified GHC.Num as Happy_Prelude
+import qualified GHC.Err as Happy_Prelude
 import qualified Data.Array as Happy_Data_Array
-import qualified Data.List as Happy_Data_List
 import qualified Data.Bits as Bits
 import qualified GHC.Exts as Happy_GHC_Exts
 import Control.Applicative(Applicative(..))
 import Control.Monad (ap)
 
--- parser produced by Happy Version 3.0
+-- parser produced by Happy Version 2.1.1
 
 newtype HappyAbsSyn  = HappyAbsSyn HappyAny
 #if __GLASGOW_HASKELL__ >= 607
@@ -260,13 +269,13 @@ happyReduceArr = Happy_Data_Array.array (1, 56) [
 happyRuleArr :: HappyAddr
 happyRuleArr = HappyA# "\x00\x00\x00\x00\x03\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00\x06\x00\x00\x00\x03\x00\x00\x00\x07\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x04\x00\x00\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x01\x00\x00\x00\x05\x00\x00\x00\x03\x00\x00\x00\x06\x00\x00\x00\x03\x00\x00\x00\x06\x00\x00\x00\x01\x00\x00\x00\x07\x00\x00\x00\x04\x00\x00\x00\x07\x00\x00\x00\x03\x00\x00\x00\x08\x00\x00\x00\x01\x00\x00\x00\x08\x00\x00\x00\x04\x00\x00\x00\x09\x00\x00\x00\x01\x00\x00\x00\x09\x00\x00\x00\x00\x00\x00\x00\x0a\x00\x00\x00\x01\x00\x00\x00\x0a\x00\x00\x00\x02\x00\x00\x00\x0b\x00\x00\x00\x01\x00\x00\x00\x0b\x00\x00\x00\x03\x00\x00\x00\x0c\x00\x00\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x01\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x02\x00\x00\x00\x0d\x00\x00\x00\x01\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0e\x00\x00\x00\x01\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0e\x00\x00\x00\x04\x00\x00\x00\x0e\x00\x00\x00\x05\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0e\x00\x00\x00\x01\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x02\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\x00\x0f\x00\x00\x00\x01\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x02\x00\x00\x00\x10\x00\x00\x00\x01\x00\x00\x00\x11\x00\x00\x00\x02\x00\x00\x00\x12\x00\x00\x00\x02\x00\x00\x00\x12\x00\x00\x00\x00\x00\x00\x00\x13\x00\x00\x00\x01\x00\x00\x00\x13\x00\x00\x00\x00\x00\x00\x00"#
 
-happyCatchStates :: [Prelude.Int]
+happyCatchStates :: [Happy_Prelude.Int]
 happyCatchStates = []
 
-happy_n_terms = 32 :: Prelude.Int
-happy_n_nonterms = 20 :: Prelude.Int
+happy_n_terms = 32 :: Happy_Prelude.Int
+happy_n_nonterms = 20 :: Happy_Prelude.Int
 
-happy_n_starts = 1 :: Prelude.Int
+happy_n_starts = 1 :: Happy_Prelude.Int
 
 happyReduce_1 :: () => Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> P (HappyAbsSyn )
 happyReduce_1 = happySpecReduce_3  0# happyReduction_1
@@ -613,7 +622,7 @@ happyReduction_35 happy_x_2
         happy_x_1
          =  case happyOutTok happy_x_2 of { (TokenInfo happy_var_2 TokCodeQuote) -> 
         happyIn19
-                 (TokenMonad "()" happy_var_2 "Prelude.>>=" "Prelude.return"
+                 (TokenMonad "()" happy_var_2 "Happy_Prelude.>>=" "Happy_Prelude.return"
         )}
 
 happyReduce_36 :: () => Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> P (HappyAbsSyn )
@@ -624,7 +633,7 @@ happyReduction_36 happy_x_3
          =  case happyOutTok happy_x_2 of { (TokenInfo happy_var_2 TokCodeQuote) -> 
         case happyOutTok happy_x_3 of { (TokenInfo happy_var_3 TokCodeQuote) -> 
         happyIn19
-                 (TokenMonad happy_var_2 happy_var_3 "Prelude.>>=" "Prelude.return"
+                 (TokenMonad happy_var_2 happy_var_3 "Happy_Prelude.>>=" "Happy_Prelude.return"
         )}}
 
 happyReduce_37 :: () => Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> P (HappyAbsSyn )
@@ -859,27 +868,27 @@ happyReport _ = happyReport'
 
 
 happyThen :: () => (P a) -> (a -> (P b)) -> (P b)
-happyThen = (Prelude.>>=)
+happyThen = (Happy_Prelude.>>=)
 happyReturn :: () => a -> (P a)
-happyReturn = (Prelude.return)
+happyReturn = (Happy_Prelude.return)
 happyParse :: () => Happy_GHC_Exts.Int# -> P (HappyAbsSyn )
 
 happyNewToken :: () => Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn ))
 
 happyDoAction :: () => Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn ))
 
-happyReduceArr :: () => Happy_Data_Array.Array Prelude.Int (Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn )))
+happyReduceArr :: () => Happy_Data_Array.Array Happy_Prelude.Int (Happy_GHC_Exts.Int# -> Token -> Happy_GHC_Exts.Int# -> Happy_IntList -> HappyStk (HappyAbsSyn ) -> (P (HappyAbsSyn )))
 
 happyThen1 :: () => P a -> (a -> P b) -> P b
 happyThen1 = happyThen
 happyFmap1 f m = happyThen m (\a -> happyReturn (f a))
 happyReturn1 :: () => a -> (P a)
 happyReturn1 = happyReturn
-happyReport' :: () => (Token) -> [Prelude.String] -> (P a) -> (P a)
+happyReport' :: () => (Token) -> [Happy_Prelude.String] -> (P a) -> (P a)
 happyReport' = (\tokens expected resume -> happyError)
 
 happyAbort :: () => (P a)
-happyAbort = Prelude.error "Called abort handler in non-resumptive parser"
+happyAbort = Happy_Prelude.error "Called abort handler in non-resumptive parser"
 
 ourParser = happySomeParser where
  happySomeParser = happyThen (happyParse 0#) (\x -> happyReturn (let {(HappyWrap5 x') = happyOut5 x} in x'))
@@ -900,9 +909,9 @@ happyError = failP (\l -> show l ++ ": Parse error\n")
 #include "MachDeps.h"
 
 -- Do not remove this comment. Required to fix CPP parsing when using GCC and a clang-compiled alex.
-#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Prelude.Bool)
-#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Prelude.Bool)
-#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Prelude.Bool)
+#define LT(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.<# m)) :: Happy_Prelude.Bool)
+#define GTE(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.>=# m)) :: Happy_Prelude.Bool)
+#define EQ(n,m) ((Happy_GHC_Exts.tagToEnum# (n Happy_GHC_Exts.==# m)) :: Happy_Prelude.Bool)
 #define PLUS(n,m) (n Happy_GHC_Exts.+# m)
 #define MINUS(n,m) (n Happy_GHC_Exts.-# m)
 #define TIMES(n,m) (n Happy_GHC_Exts.*# m)
@@ -926,10 +935,10 @@ data Happy_IntList = HappyCons Happy_Int Happy_IntList
 #endif
 
 #if defined(HAPPY_DEBUG)
-#  define DEBUG_TRACE(s)    (happyTrace (s)) Prelude.$
-happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Prelude.$ do
+#  define DEBUG_TRACE(s)    (happyTrace (s)) Happy_Prelude.$
+happyTrace string expr = Happy_System_IO_Unsafe.unsafePerformIO Happy_Prelude.$ do
     Happy_System_IO.hPutStr Happy_System_IO.stderr string
-    Prelude.return expr
+    Happy_Prelude.return expr
 #else
 #  define DEBUG_TRACE(s)    {- nothing -}
 #endif
@@ -957,23 +966,23 @@ happyAccept j tk st sts (HappyStk ans _) =
 -- Arrays only: do the next action
 
 happyDoAction i tk st =
-  DEBUG_TRACE("state: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++
-              ",\ttoken: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++
+  DEBUG_TRACE("state: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++
+              ",\ttoken: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++
               ",\taction: ")
   case happyDecodeAction (happyNextAction i st) of
     HappyFail             -> DEBUG_TRACE("failing.\n")
                              happyFail i tk st
     HappyAccept           -> DEBUG_TRACE("accept.\n")
                              happyAccept i tk st
-    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# rule) Prelude.++ ")")
+    HappyReduce rule      -> DEBUG_TRACE("reduce (rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# rule) Happy_Prelude.++ ")")
                              (happyReduceArr Happy_Data_Array.! (Happy_GHC_Exts.I# rule)) i tk st
-    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+    HappyShift  new_state -> DEBUG_TRACE("shift, enter state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
                              happyShift new_state i tk st
 
 {-# INLINE happyNextAction #-}
 happyNextAction i st = case happyIndexActionTable i st of
-  Prelude.Just (Happy_GHC_Exts.I# act) -> act
-  Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
+  Happy_Prelude.Just (Happy_GHC_Exts.I# act) -> act
+  Happy_Prelude.Nothing                      -> happyIndexOffAddr happyDefActions st
 
 {-# INLINE happyIndexActionTable #-}
 happyIndexActionTable i st
@@ -981,9 +990,9 @@ happyIndexActionTable i st
   -- i >= 0:   Guard against INVALID_TOK (do the default action, which ultimately errors)
   -- off >= 0: Otherwise it's a default action
   -- equality check: Ensure that the entry in the compressed array is owned by st
-  = Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
-  | Prelude.otherwise
-  = Prelude.Nothing
+  = Happy_Prelude.Just (Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off))
+  | Happy_Prelude.otherwise
+  = Happy_Prelude.Nothing
   where
     off = PLUS(happyIndexOffAddr happyActOffsets st, i)
 
@@ -992,14 +1001,14 @@ data HappyAction
   | HappyAccept
   | HappyReduce Happy_Int -- rule number
   | HappyShift Happy_Int  -- new state
-  deriving Prelude.Show
+  deriving Happy_Prelude.Show
 
 {-# INLINE happyDecodeAction #-}
 happyDecodeAction :: Happy_Int -> HappyAction
 happyDecodeAction  0#                        = HappyFail
 happyDecodeAction -1#                        = HappyAccept
 happyDecodeAction action | LT(action, 0#)    = HappyReduce NEGATE(PLUS(action, 1#))
-                         | Prelude.otherwise = HappyShift MINUS(action, 1#)
+                         | Happy_Prelude.otherwise = HappyShift MINUS(action, 1#)
 
 {-# INLINE happyIndexGotoTable #-}
 happyIndexGotoTable nt st = happyIndexOffAddr happyTable off
@@ -1098,7 +1107,7 @@ happyDropStk n  (x `HappyStk` xs) = happyDropStk MINUS(n,(1#::Happy_Int)) xs
 -- Moving to a new state after a reduction
 
 happyGoto nt j tk st =
-   DEBUG_TRACE(", goto state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
+   DEBUG_TRACE(", goto state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
    happyDoAction j tk new_state
   where new_state = happyIndexGotoTable nt st
 
@@ -1148,8 +1157,8 @@ It is best understood by example. Consider
 Exp :: { String }
 Exp : '1'                { "1" }
     | catch              { "catch" }
-    | Exp '+' Exp %shift { $1 Prelude.++ " + " Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
-    | '(' Exp ')'        { "(" Prelude.++ $2 Prelude.++ ")" }
+    | Exp '+' Exp %shift { $1 Happy_Prelude.++ " + " Happy_Prelude.++ $3 } -- %shift: associate 1 + 1 + 1 to the right
+    | '(' Exp ')'        { "(" Happy_Prelude.++ $2 Happy_Prelude.++ ")" }
 
 The idea of the use of `catch` here is that upon encountering a parse error
 during expression parsing, we can gracefully degrade using the `catch` rule,
@@ -1257,73 +1266,73 @@ happyFixupFailed tk st sts (x `HappyStk` stk) =
 happyResume i tk st sts stk = pop_items [] st sts stk
   where
     !(Happy_GHC_Exts.I# n_starts) = happy_n_starts   -- this is to test whether we have a start token
-    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Prelude.- 1   -- this is the token number of the EOF token
-    happy_list_to_list :: Happy_IntList -> [Prelude.Int]
+    !(Happy_GHC_Exts.I# eof_i) = happy_n_terms Happy_Prelude.- 1   -- this is the token number of the EOF token
+    happy_list_to_list :: Happy_IntList -> [Happy_Prelude.Int]
     happy_list_to_list (HappyCons st sts)
       | LT(st, n_starts)
       = [(Happy_GHC_Exts.I# st)]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = (Happy_GHC_Exts.I# st) : happy_list_to_list sts
 
     -- See (1) of Note [happyResume]
     pop_items catch_frames st sts stk
       | LT(st, n_starts)
-      = DEBUG_TRACE("reached start state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", ")
-        if Prelude.null catch_frames_new
+      = DEBUG_TRACE("reached start state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", ")
+        if Happy_Prelude.null catch_frames_new
           then DEBUG_TRACE("no resumption.\n")
                happyAbort
-          else DEBUG_TRACE("now discard input, trying to anchor in states " Prelude.++ Prelude.show (Prelude.map (happy_list_to_list . Prelude.fst) (Prelude.reverse catch_frames_new)) Prelude.++ ".\n")
-               discard_input_until_exp i tk (Prelude.reverse catch_frames_new)
+          else DEBUG_TRACE("now discard input, trying to anchor in states " Happy_Prelude.++ Happy_Prelude.show (Happy_Prelude.map (happy_list_to_list . Happy_Prelude.fst) (Happy_Prelude.reverse catch_frames_new)) Happy_Prelude.++ ".\n")
+               discard_input_until_exp i tk (Happy_Prelude.reverse catch_frames_new)
       | (HappyCons st1 sts1) <- sts, _ `HappyStk` stk1 <- stk
       = pop_items catch_frames_new st1 sts1 stk1
       where
         !catch_frames_new
           | HappyShift new_state <- happyDecodeAction (happyNextAction CATCH_TOK st)
-          , DEBUG_TRACE("can shift catch token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", into state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# new_state) Prelude.++ "\n")
-            Prelude.null (Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
+          , DEBUG_TRACE("can shift catch token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", into state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# new_state) Happy_Prelude.++ "\n")
+            Happy_Prelude.null (Happy_Prelude.filter (\(HappyCons _ (HappyCons h _),_) -> EQ(st,h)) catch_frames)
           = (HappyCons new_state (HappyCons st sts), MK_ERROR_TOKEN(i) `HappyStk` stk):catch_frames -- MK_ERROR_TOKEN(i) is just some dummy that should not be accessed by user code
-          | Prelude.otherwise
-          = DEBUG_TRACE("already shifted or can't shift catch in " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ "\n")
+          | Happy_Prelude.otherwise
+          = DEBUG_TRACE("already shifted or can't shift catch in " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ "\n")
             catch_frames
 
     -- See (2) of Note [happyResume]
     discard_input_until_exp i tk catch_frames
-      | Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
-      = DEBUG_TRACE("found expected token in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ " after shifting from " Prelude.++ Prelude.show (Happy_GHC_Exts.I# catch_st) Prelude.++ ": " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.Just (HappyCons st (HappyCons catch_st sts), catch_frame) <- some_catch_state_shifts i catch_frames
+      = DEBUG_TRACE("found expected token in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ " after shifting from " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# catch_st) Happy_Prelude.++ ": " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyDoAction i tk st (HappyCons catch_st sts) catch_frame
       | EQ(i,eof_i) -- is i EOF?
       = DEBUG_TRACE("reached EOF, cannot resume. abort parse :(\n")
         happyAbort
-      | Prelude.otherwise
-      = DEBUG_TRACE("discard token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ "\n")
+      | Happy_Prelude.otherwise
+      = DEBUG_TRACE("discard token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ "\n")
         happyLex (\eof_tk -> discard_input_until_exp eof_i eof_tk catch_frames) -- eof
                  (\i tk   -> discard_input_until_exp i tk catch_frames)         -- not eof
 
-    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Prelude.Nothing
+    some_catch_state_shifts _ [] = DEBUG_TRACE("no catch state could shift.\n") Happy_Prelude.Nothing
     some_catch_state_shifts i catch_frames@(((HappyCons st sts),_):_) = try_head i st sts catch_frames
       where
         try_head i st sts catch_frames = -- PRECONDITION: head catch_frames = (HappyCons st sts)
-          DEBUG_TRACE("trying token " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ " in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ": ")
+          DEBUG_TRACE("trying token " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ " in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ": ")
           case happyDecodeAction (happyNextAction i st) of
-            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Prelude.tail catch_frames)
-            HappyAccept   -> DEBUG_TRACE("accept.\n") Prelude.Just (Prelude.head catch_frames)
-            HappyShift _  -> DEBUG_TRACE("shift.\n")  Prelude.Just (Prelude.head catch_frames)
+            HappyFail     -> DEBUG_TRACE("fail.\n")   some_catch_state_shifts i (Happy_Prelude.tail catch_frames)
+            HappyAccept   -> DEBUG_TRACE("accept.\n") Happy_Prelude.Just (Happy_Prelude.head catch_frames)
+            HappyShift _  -> DEBUG_TRACE("shift.\n")  Happy_Prelude.Just (Happy_Prelude.head catch_frames)
             HappyReduce r -> case happySimulateReduce r st sts of
               (HappyCons st1 sts1) -> try_head i st1 sts1 catch_frames
 
 happySimulateReduce r st sts =
-  DEBUG_TRACE("simulate reduction of rule " Prelude.++ Prelude.show (Happy_GHC_Exts.I# r) Prelude.++ ", ")
+  DEBUG_TRACE("simulate reduction of rule " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# r) Happy_Prelude.++ ", ")
   let (# nt, len #) = happyIndexRuleArr r in
-  DEBUG_TRACE("nt " Prelude.++ Prelude.show (Happy_GHC_Exts.I# nt) Prelude.++ ", len: " Prelude.++ Prelude.show (Happy_GHC_Exts.I# len) Prelude.++ ", new_st ")
+  DEBUG_TRACE("nt " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# nt) Happy_Prelude.++ ", len: " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# len) Happy_Prelude.++ ", new_st ")
   let !(sts1@(HappyCons st1 _)) = happyDrop len (HappyCons st sts)
       new_st = happyIndexGotoTable nt st1 in
-  DEBUG_TRACE(Prelude.show (Happy_GHC_Exts.I# new_st) Prelude.++ ".\n")
+  DEBUG_TRACE(Happy_Prelude.show (Happy_GHC_Exts.I# new_st) Happy_Prelude.++ ".\n")
   (HappyCons new_st sts1)
 
-happyTokenToString :: Prelude.Int -> Prelude.String
-happyTokenToString i = happyTokenStrings Prelude.!! (i Prelude.- 2) -- 2: errorTok, catchTok
+happyTokenToString :: Happy_Prelude.Int -> Happy_Prelude.String
+happyTokenToString i = happyTokenStrings Happy_Prelude.!! (i Happy_Prelude.- 2) -- 2: errorTok, catchTok
 
-happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
+happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Happy_Prelude.String]
 -- Upon a parse error, we want to suggest tokens that are expected in that
 -- situation. This function computes such tokens.
 -- It works by examining the top of the state stack.
@@ -1334,15 +1343,15 @@ happyExpectedTokens :: Happy_Int -> Happy_IntList -> [Prelude.String]
 -- returned.
 happyExpectedTokens st sts =
   DEBUG_TRACE("constructing expected tokens.\n")
-  Prelude.map happyTokenToString (search_shifts st sts [])
+  Happy_Prelude.map happyTokenToString (search_shifts st sts [])
   where
-    search_shifts st sts shifts = Prelude.foldr (add_action st sts) shifts (distinct_actions st)
+    search_shifts st sts shifts = Happy_Prelude.foldr (add_action st sts) shifts (distinct_actions st)
     add_action st sts (Happy_GHC_Exts.I# i, Happy_GHC_Exts.I# act) shifts =
-      DEBUG_TRACE("found action in state " Prelude.++ Prelude.show (Happy_GHC_Exts.I# st) Prelude.++ ", input " Prelude.++ Prelude.show (Happy_GHC_Exts.I# i) Prelude.++ ", " Prelude.++ Prelude.show (happyDecodeAction act) Prelude.++ "\n")
+      DEBUG_TRACE("found action in state " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# st) Happy_Prelude.++ ", input " Happy_Prelude.++ Happy_Prelude.show (Happy_GHC_Exts.I# i) Happy_Prelude.++ ", " Happy_Prelude.++ Happy_Prelude.show (happyDecodeAction act) Happy_Prelude.++ "\n")
       case happyDecodeAction act of
         HappyFail     -> shifts
         HappyAccept   -> shifts -- This would always be %eof or error... Not helpful
-        HappyShift _  -> Happy_Data_List.insert (Happy_GHC_Exts.I# i) shifts
+        HappyShift _  -> Happy_Prelude.insert (Happy_GHC_Exts.I# i) shifts
         HappyReduce r -> case happySimulateReduce r st sts of
           (HappyCons st1 sts1) -> search_shifts st1 sts1 shifts
     distinct_actions st
@@ -1357,13 +1366,13 @@ happyExpectedTokens st sts =
       , GTE(off_i,0#)
       , EQ(happyIndexOffAddr happyCheck off_i,i)
       = [(Happy_GHC_Exts.I# (happyIndexOffAddr happyTable off_i))]
-      | Prelude.otherwise
+      | Happy_Prelude.otherwise
       = []
 
 -- Internal happy errors:
 
 notHappyAtAll :: a
-notHappyAtAll = Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
+notHappyAtAll = Happy_Prelude.error "Internal Happy parser panic. This is not supposed to happen! Please open a bug report at https://github.com/haskell/happy/issues.\n"
 
 -----------------------------------------------------------------------------
 -- Hack to get the typechecker to accept our action functions
@@ -1375,11 +1384,11 @@ happyTcHack x y = y
 -----------------------------------------------------------------------------
 -- Seq-ing.  If the --strict flag is given, then Happy emits
 --      happySeq = happyDoSeq
--- Prelude.otherwise it emits
+-- otherwise it emits
 --      happySeq = happyDontSeq
 
 happyDoSeq, happyDontSeq :: a -> b -> b
-happyDoSeq   a b = a `Prelude.seq` b
+happyDoSeq   a b = a `Happy_GHC_Exts.seq` b
 happyDontSeq a b = b
 
 -----------------------------------------------------------------------------

--- a/lib/happy-lib.cabal
+++ b/lib/happy-lib.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: happy-lib
-version: 2.1.1
+version: 2.1.2
 license: BSD-2-Clause
 copyright: (c) Andy Gill, Simon Marlow
 author: Andy Gill and Simon Marlow

--- a/tests/issue131.y
+++ b/tests/issue131.y
@@ -1,18 +1,18 @@
 {
 module Main where
 import Prelude ()
-import qualified Prelude
+import qualified Prelude as Pre
 }
 
 %name parser
 %token foo { 1 }
-%tokentype { Prelude.Int }
+%tokentype { Pre.Int }
 
 %%
 
 Foo : foo { () }
 
 {
-main = Prelude.putStrLn "Test works"
-happyError = Prelude.undefined
+main = Pre.putStrLn "Test works"
+happyError = Pre.undefined
 }


### PR DESCRIPTION
This is in order to undo a breaking change caused by users writing `import Prelude hiding (null)`.

Fixes #325.