### PR TITLE
Auto-resolve shift/reduce conflicts involving the catch token

### DIFF
--- a/happy.cabal
+++ b/happy.cabal
@@ -1,5 +1,5 @@
 name: happy
-version: 2.1.2
+version: 2.1.3
 license: BSD2
 license-file: LICENSE
 copyright: (c) Andy Gill, Simon Marlow
@@ -139,7 +139,7 @@ executable happy
                  array,
                  containers >= 0.4.2,
                  mtl >= 2.2.1,
-                 happy-lib == 2.1.2
+                 happy-lib == 2.1.3
 
   default-language: Haskell98
   default-extensions: CPP, MagicHash, FlexibleContexts, NamedFieldPuns

--- a/lib/grammar/src/Happy/Grammar.lhs
+++ b/lib/grammar/src/Happy/Grammar.lhs
@@ -175,6 +175,10 @@ For array-based parsers, see the note in Tabular/LALR.lhs.
 > catchName = "catch"
 > dummyName = "%dummy"  -- shouldn't occur in the grammar anywhere
 
+TODO: Should rename firstStartTok to firstStartName!
+It denotes the *Name* of the first start non-terminal and semantically has
+nothing to do with Tokens at all.
+
 > firstStartTok, dummyTok, errorTok, catchTok, epsilonTok :: Name
 > firstStartTok   = MkName 4
 > dummyTok        = MkName 3

--- a/lib/happy-lib.cabal
+++ b/lib/happy-lib.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: happy-lib
-version: 2.1.2
+version: 2.1.3
 license: BSD-2-Clause
 copyright: (c) Andy Gill, Simon Marlow
 author: Andy Gill and Simon Marlow

--- a/tests/catch-shift-reduce.y
+++ b/tests/catch-shift-reduce.y
@@ -1,0 +1,50 @@
+{
+module Main where
+
+import Data.Char
+}
+
+%name parseExp Exp
+%tokentype { Token }
+%error { abort } { reportError }
+
+%monad { ParseM } { (>>=) } { return }
+
+%token
+  '1' { TOne }
+  '+' { TPlus }
+  '(' { TOpen }
+  ')' { TClose }
+
+%right '+'
+%expect 0     -- The point of this test: The List productions should expose a shift/reduce conflict because of catch
+
+%%
+
+Close :: { String }
+Close : ')'   { ")" }
+      | catch { "catch" }
+
+Exp :: { String }
+Exp : catch          { "catch" }
+    | '1'            { "1"}
+    | '(' List Close { "(" ++ $2 ++ $3 }
+
+List :: { String }
+     : Exp '+' { $1 ++ "+" }
+     | Exp '+' Exp { $1 ++ "+" ++ $3 }
+
+{
+data Token = TOne | TPlus | TComma | TOpen | TClose
+
+type ParseM = Maybe
+
+abort :: [Token] -> ParseM a
+abort = undefined
+
+reportError :: [Token] -> ([Token] -> ParseM a) -> ParseM a
+reportError = undefined
+
+main :: IO ()
+main = return ()
+}


### PR DESCRIPTION
When the current token is the catch token, we never reduce; we only ever shift (see the [user's guide](https://haskell-happy.readthedocs.io/en/latest/using.html#resumptive-parsing-with-catch) for how `catch` works). More precisely, the mechanism considers multiple situations in which the `catch` token can be shifted in parallel, including situations that are reachable via reductions. Hence it does not make sense to report shift/reduce conflicts involving the catch token: Error resumption mode will only ever try to shift it.

The solution implemented in this patch is not to generate conflicting `LR'Reduce` actions in the first place by deleting the `catch` token from the lookahead sets of LR1 items.